### PR TITLE
Mockup Schedule Page (prototype draft 01)

### DIFF
--- a/src/main/webapp/src/app/app-routing.module.ts
+++ b/src/main/webapp/src/app/app-routing.module.ts
@@ -31,7 +31,7 @@ const routes: Routes = [
   {path: 'page/index', component: IndexComponent},
   {path: 'page/test-page1', component: TestPage1Component},
   {path: 'page/test-page2', component: TestPage2Component},
-  {path: 'page/schedule-page', component: SchedulePageComponent},
+  {path: 'page/schedule', component: SchedulePageComponent},
   /** Defaults to /index */
   {path: '', redirectTo: '/page/index', pathMatch: 'full'},
 ];

--- a/src/main/webapp/src/app/app-routing.module.ts
+++ b/src/main/webapp/src/app/app-routing.module.ts
@@ -18,6 +18,7 @@ import {Routes, RouterModule} from '@angular/router';
 import {IndexComponent} from './index/index.component';
 import {TestPage1Component} from './test-page1/test-page1.component';
 import {TestPage2Component} from './test-page2/test-page2.component';
+import {SchedulePageComponent} from './schedule-page/schedule-page.component';
 
 /**
  * The routing table for all frontend pages
@@ -30,6 +31,7 @@ const routes: Routes = [
   {path: 'page/index', component: IndexComponent},
   {path: 'page/test-page1', component: TestPage1Component},
   {path: 'page/test-page2', component: TestPage2Component},
+  {path: 'page/schedule-page', component: SchedulePageComponent},
   /** Defaults to /index */
   {path: '', redirectTo: '/page/index', pathMatch: 'full'},
 ];

--- a/src/main/webapp/src/app/app.component.css
+++ b/src/main/webapp/src/app/app.component.css
@@ -15,3 +15,7 @@ a {
   color: inherit;
   text-decoration: inherit;
 }
+
+mat-toolbar {
+  background-color: #58D68D;
+}

--- a/src/main/webapp/src/app/app.component.css
+++ b/src/main/webapp/src/app/app.component.css
@@ -15,7 +15,3 @@ a {
   color: inherit;
   text-decoration: inherit;
 }
-
-mat-toolbar {
-  background-color: #58D68D;
-}

--- a/src/main/webapp/src/app/app.component.html
+++ b/src/main/webapp/src/app/app.component.html
@@ -1,6 +1,6 @@
 <!-- Template page: these components will appear on
 every page unless they are suppressed. -->
-<mat-toolbar id="growpod-top-bar" color="primary">
+<mat-toolbar id="growpod-top-bar">
   <mat-toolbar-row>
     <a routerLink="/page/index"><span>GrowPod</span></a>
     <span class="growpod-spacer"></span>

--- a/src/main/webapp/src/app/app.component.html
+++ b/src/main/webapp/src/app/app.component.html
@@ -1,6 +1,6 @@
 <!-- Template page: these components will appear on
 every page unless they are suppressed. -->
-<mat-toolbar id="growpod-top-bar">
+<mat-toolbar>
   <mat-toolbar-row>
     <a routerLink="/page/index"><span>GrowPod</span></a>
     <span class="growpod-spacer"></span>

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -18,11 +18,14 @@ import {NgModule} from '@angular/core';
 import {AppRoutingModule} from './app-routing.module';
 import {MaterialComponents} from './common/material-components';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {MatExpansionModule} from '@angular/material/expansion';
+import {MatCardModule} from '@angular/material/card';
 
 import {AppComponent} from './app.component';
 import {IndexComponent} from './index/index.component';
 import {TestPage1Component} from './test-page1/test-page1.component';
 import {TestPage2Component} from './test-page2/test-page2.component';
+import {SchedulePageComponent} from './schedule-page/schedule-page.component';
 
 @NgModule({
   declarations: [
@@ -30,12 +33,15 @@ import {TestPage2Component} from './test-page2/test-page2.component';
     IndexComponent,
     TestPage1Component,
     TestPage2Component,
+    SchedulePageComponent,
   ],
   imports: [
     MaterialComponents,
     BrowserModule,
     AppRoutingModule,
     BrowserAnimationsModule,
+    MatExpansionModule,
+    MatCardModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -20,6 +20,11 @@ import {MaterialComponents} from './common/material-components';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {MatCardModule} from '@angular/material/card';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {MatNativeDateModule} from '@angular/material/core';
+
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {MatInputModule} from '@angular/material/input';
 
 import {AppComponent} from './app.component';
 import {IndexComponent} from './index/index.component';
@@ -42,6 +47,11 @@ import {SchedulePageComponent} from './schedule-page/schedule-page.component';
     BrowserAnimationsModule,
     MatExpansionModule,
     MatCardModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatDatepickerModule,
+    MatInputModule,
+    MatNativeDateModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.css
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.css
@@ -16,19 +16,17 @@
   right: 0;
 }
 
-/* colors */
-/*
-dark green: #12a45f;
-green: #58d68d;
-white: #ffffff;
-
-*/
 .card-padding {
   padding: 20px;
 }
 
 mat-card {
   background-color: #58D68D;
+}
+
+.today-event {
+  background-color: #005C80;
+  color: white;
 }
 
 mat-expansion-panel,
@@ -53,3 +51,4 @@ mat-panel-title {
   background-color: white;
   color: #005C80;
 }
+

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.css
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.css
@@ -1,19 +1,8 @@
 /* Split the screen in half */
-.split {
-  width: 50%;
-  position: fixed;
-  overflow-x: hidden;
-  padding-top: 20px;
-}
+.flex-container {
+  display: flex;
+  flex-direction: row;
 
-/* Control the left side */
-.left {
-  left: 0;
-}
-
-/* Control the right side */
-.right {
-  right: 0;
 }
 
 .card-padding {

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.css
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.css
@@ -6,7 +6,7 @@
 
 .flex-split {
   flex: 0 1 50%;
-  padding: 10em;
+  padding: 3em;
 }
 
 .card-padding {

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.css
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.css
@@ -1,0 +1,55 @@
+/* Split the screen in half */
+.split {
+  width: 50%;
+  position: fixed;
+  overflow-x: hidden;
+  padding-top: 20px;
+}
+
+/* Control the left side */
+.left {
+  left: 0;
+}
+
+/* Control the right side */
+.right {
+  right: 0;
+}
+
+/* colors */
+/*
+dark green: #12a45f;
+green: #58d68d;
+white: #ffffff;
+
+*/
+.card-padding {
+  padding: 20px;
+}
+
+mat-card {
+  background-color: #58D68D;
+}
+
+mat-expansion-panel,
+mat-panel-title {
+  background-color: #005C80;
+  color: white;
+}
+
+.button-style {
+  display: block;
+  padding: 0.5em 3em;
+  text-decoration: none;
+  border: none;
+  box-sizing: border-box;
+  box-shadow:inset 0 -0.6em 0 -0.35em #003353;
+  background-color: #005C80;
+  color: white;
+}
+
+.button-style:hover {
+  box-shadow:inset 0 -0.6em 0 -0.35em whitesmoke;
+  background-color: white;
+  color: #005C80;
+}

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.css
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.css
@@ -20,21 +20,6 @@
   padding: 20px;
 }
 
-mat-card {
-  background-color: #58D68D;
-}
-
-.today-event {
-  background-color: #005C80;
-  color: white;
-}
-
-mat-expansion-panel,
-mat-panel-title {
-  background-color: #005C80;
-  color: white;
-}
-
 .button-style {
   display: block;
   padding: 0.5em 3em;
@@ -51,4 +36,3 @@ mat-panel-title {
   background-color: white;
   color: #005C80;
 }
-

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.css
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.css
@@ -2,7 +2,11 @@
 .flex-container {
   display: flex;
   flex-direction: row;
+}
 
+.flex-split {
+  flex: 0 1 50%;
+  padding: 10em;
 }
 
 .card-padding {

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.html
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.html
@@ -1,79 +1,81 @@
-<div class='split left'>
-  <div class='card-padding'>
-    <mat-card>
-      <h2> Peapod Garden </h2>
-      <h4> Caroline | New York City, NY </h4>
-      <button md-raised-button class='button-style'> Go back </button>
-    </mat-card>
+<div class='flex-container'>
+  <div style='flex-grow: 2'>
+    <div class='card-padding'>
+      <mat-card>
+        <h2> Peapod Garden </h2>
+        <h4> Caroline | New York City, NY </h4>
+        <button md-raised-button class='button-style'> Go back </button>
+      </mat-card>
+    </div>
+
+    <div class='card-padding'>
+      <mat-card>
+        <mat-accordion>
+          <mat-expansion-panel hideToggle>
+            <mat-expansion-panel-header>
+              <mat-panel-title> About the garden </mat-panel-title>
+            </mat-expansion-panel-header>
+              <p>Growing all the green things that look like peas.</p>
+          </mat-expansion-panel>
+
+          <mat-expansion-panel hideToggle>
+            <mat-expansion-panel-header>
+              <mat-panel-title> Plants </mat-panel-title>
+            </mat-expansion-panel-header>
+              <ul>
+                <li>Pea plant</li>
+                <li>Pears</li>
+              </ul>
+          </mat-expansion-panel>
+
+          <mat-expansion-panel hideToggle>
+            <mat-expansion-panel-header>
+              <mat-panel-title> Members </mat-panel-title>
+            </mat-expansion-panel-header>
+              <ul>
+                <li>Caroline (owner)</li>
+                <li>Jake</li>
+                <li>Kayla</li>
+                <li>Cody</li>
+                <li>Stephanie</li>
+              </ul>
+          </mat-expansion-panel>
+        </mat-accordion>
+      </mat-card>
+    </div>
   </div>
 
-  <div class='card-padding'>
-    <mat-card>
-      <mat-accordion>
-        <mat-expansion-panel hideToggle>
-          <mat-expansion-panel-header>
-            <mat-panel-title> About the garden </mat-panel-title>
-          </mat-expansion-panel-header>
-            <p>Growing all the green things that look like peas.</p>
-        </mat-expansion-panel>
-
-        <mat-expansion-panel hideToggle>
-          <mat-expansion-panel-header>
-            <mat-panel-title> Plants </mat-panel-title>
-          </mat-expansion-panel-header>
-            <ul>
-              <li>Pea plant</li>
-              <li>Pears</li>
-            </ul>
-        </mat-expansion-panel>
-
-        <mat-expansion-panel hideToggle>
-          <mat-expansion-panel-header>
-            <mat-panel-title> Members </mat-panel-title>
-          </mat-expansion-panel-header>
-            <ul>
-              <li>Caroline (owner)</li>
-              <li>Jake</li>
-              <li>Kayla</li>
-              <li>Cody</li>
-              <li>Stephanie</li>
-            </ul>
-        </mat-expansion-panel>
-      </mat-accordion>
-    </mat-card>
-  </div>
-</div>
-
-<div class='split right'>
-  <div class='card-padding'>
-    <mat-card>
-      <mat-card-title> Daily Tasks Schedule </mat-card-title>
-
-      <mat-form-field appearance="fill">
-        <mat-label>Select date to view tasks</mat-label>
-        <input matInput [matDatepicker]="datepicker"
-              [formControl]="date">
-        <mat-datepicker-toggle matSuffix [for]="datepicker"></mat-datepicker-toggle>
-        <mat-datepicker #datepicker></mat-datepicker>
-      </mat-form-field>
-
-      <h1>Tuesday: June 20</h1>
-
+  <div style='flex-grow: 4'>
+    <div class='card-padding'>
       <mat-card>
-        <mat-card-title> 9:00 am | Water Plants </mat-card-title>
-        <h3> Member(s): Cody, Stephanie, Kayla </h3>
-        <mat-card-content>
-          <p> Make sure to water all plants in section 1A </p>
-        </mat-card-content>
-      </mat-card>
+        <mat-card-title> Daily Tasks Schedule </mat-card-title>
 
-      <mat-card>
-        <mat-card-title> 11:00 am | Pick pears </mat-card-title>
-        <h3> Member(s): Caroline, Jake </h3>
-        <mat-card-content>
-          <p> Put the pears in a basket for pickup for tomorrow. </p>
-        </mat-card-content>
+        <mat-form-field appearance="fill">
+          <mat-label>Select date to view tasks</mat-label>
+          <input matInput [matDatepicker]="datepicker"
+                [formControl]="date">
+          <mat-datepicker-toggle matSuffix [for]="datepicker"></mat-datepicker-toggle>
+          <mat-datepicker #datepicker></mat-datepicker>
+        </mat-form-field>
+
+        <h1>Tuesday: June 20</h1>
+
+        <mat-card>
+          <mat-card-title> 9:00 am | Water Plants </mat-card-title>
+          <h3> Member(s): Cody, Stephanie, Kayla </h3>
+          <mat-card-content>
+            <p> Make sure to water all plants in section 1A </p>
+          </mat-card-content>
+        </mat-card>
+
+        <mat-card>
+          <mat-card-title> 11:00 am | Pick pears </mat-card-title>
+          <h3> Member(s): Caroline, Jake </h3>
+          <mat-card-content>
+            <p> Put the pears in a basket for pickup for tomorrow. </p>
+          </mat-card-content>
+        </mat-card>
       </mat-card>
-    </mat-card>
+    </div>
   </div>
 </div>

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.html
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.html
@@ -59,7 +59,7 @@
 
       <h1>Tuesday: June 20</h1>
 
-      <mat-card class='today-event'>
+      <mat-card>
         <mat-card-title> 9:00 am | Water Plants </mat-card-title>
         <h3> Member(s): Cody, Stephanie, Kayla </h3>
         <mat-card-content>
@@ -67,7 +67,7 @@
         </mat-card-content>
       </mat-card>
 
-      <mat-card class='today-event'>
+      <mat-card>
         <mat-card-title> 11:00 am | Pick pears </mat-card-title>
         <h3> Member(s): Caroline, Jake </h3>
         <mat-card-content>

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.html
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.html
@@ -1,5 +1,5 @@
 <div class='flex-container'>
-  <div style='flex-grow: 2'>
+  <div class='flex-split'>
     <div class='card-padding'>
       <mat-card>
         <h2> Peapod Garden </h2>
@@ -45,7 +45,7 @@
     </div>
   </div>
 
-  <div style='flex-grow: 4'>
+  <div class='flex-split'>
     <div class='card-padding'>
       <mat-card>
         <mat-card-title> Daily Tasks Schedule </mat-card-title>

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.html
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.html
@@ -1,0 +1,53 @@
+<div class='split left'>
+  <div class='card-padding'>
+    <mat-card>
+      <h2> Peapod Garden </h2>
+      <h4> Caroline | New York City, NY </h4>
+      <button md-raised-button class='button-style'> Go back </button>
+    </mat-card>
+  </div>
+
+  <div class='card-padding'>
+    <mat-card>
+      <mat-accordion>
+        <mat-expansion-panel hideToggle>
+          <mat-expansion-panel-header>
+            <mat-panel-title> Stats </mat-panel-title>
+          </mat-expansion-panel-header>
+            <p>This garden has been active for 31 days.</p>
+        </mat-expansion-panel>
+
+        <mat-expansion-panel hideToggle>
+          <mat-expansion-panel-header>
+            <mat-panel-title> Plants </mat-panel-title>
+          </mat-expansion-panel-header>
+            <ul>
+              <li>Pea plant</li>
+              <li>Pears</li>
+            </ul>
+        </mat-expansion-panel>
+
+        <mat-expansion-panel hideToggle>
+          <mat-expansion-panel-header>
+            <mat-panel-title> Members </mat-panel-title>
+          </mat-expansion-panel-header>
+            <ul>
+              <li>Caroline (owner)</li>
+              <li>Jake</li>
+              <li>Kayla</li>
+              <li>Cody</li>
+              <li>Stephanie</li>
+            </ul>
+        </mat-expansion-panel>
+      </mat-accordion>
+    </mat-card>
+  </div>
+</div>
+
+<div class='split right'>
+  <div class='card-padding'>
+    <mat-card>
+      <img src="https://i.ibb.co/VHrQPyD/calendar.jpg" alt="calendar" border="0">
+    </mat-card>
+  </div>
+</div>

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.html
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.html
@@ -12,9 +12,9 @@
       <mat-accordion>
         <mat-expansion-panel hideToggle>
           <mat-expansion-panel-header>
-            <mat-panel-title> Stats </mat-panel-title>
+            <mat-panel-title> About the garden </mat-panel-title>
           </mat-expansion-panel-header>
-            <p>This garden has been active for 31 days.</p>
+            <p>Growing all the green things that look like peas.</p>
         </mat-expansion-panel>
 
         <mat-expansion-panel hideToggle>
@@ -47,7 +47,33 @@
 <div class='split right'>
   <div class='card-padding'>
     <mat-card>
-      <img src="https://i.ibb.co/VHrQPyD/calendar.jpg" alt="calendar" border="0">
+      <mat-card-title> Daily Tasks Schedule </mat-card-title>
+
+      <mat-form-field appearance="fill">
+        <mat-label>Select date to view tasks</mat-label>
+        <input matInput [matDatepicker]="datepicker"
+              [formControl]="date">
+        <mat-datepicker-toggle matSuffix [for]="datepicker"></mat-datepicker-toggle>
+        <mat-datepicker #datepicker></mat-datepicker>
+      </mat-form-field>
+
+      <h1>Tuesday: June 20</h1>
+
+      <mat-card class='today-event'>
+        <mat-card-title> 9:00 am | Water Plants </mat-card-title>
+        <h3> Member(s): Cody, Stephanie, Kayla </h3>
+        <mat-card-content>
+          <p> Make sure to water all plants in section 1A </p>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card class='today-event'>
+        <mat-card-title> 11:00 am | Pick pears </mat-card-title>
+        <h3> Member(s): Caroline, Jake </h3>
+        <mat-card-content>
+          <p> Put the pears in a basket for pickup for tomorrow. </p>
+        </mat-card-content>
+      </mat-card>
     </mat-card>
   </div>
 </div>

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.spec.ts
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.spec.ts
@@ -1,0 +1,24 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {SchedulePageComponent} from './schedule-page.component';
+
+describe('SchedulePageComponent', () => {
+  let component: SchedulePageComponent;
+  let fixture: ComponentFixture<SchedulePageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SchedulePageComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SchedulePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.ts
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.ts
@@ -1,0 +1,30 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'schedule-page',
+  templateUrl: './schedule-page.component.html',
+  styleUrls: [
+    './schedule-page.component.css',
+    '../common/growpod-page-styles.css',
+  ],
+})
+
+export class SchedulePageComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/main/webapp/src/app/schedule-page/schedule-page.component.ts
+++ b/src/main/webapp/src/app/schedule-page/schedule-page.component.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {Component, OnInit} from '@angular/core';
+import {FormControl} from '@angular/forms';
 
 @Component({
   selector: 'schedule-page',
@@ -24,6 +25,9 @@ import {Component, OnInit} from '@angular/core';
 })
 
 export class SchedulePageComponent implements OnInit {
+  date = new FormControl(new Date());
+  serializedDate = new FormControl((new Date()).toISOString());
+  
   constructor() {}
 
   ngOnInit(): void {}


### PR DESCRIPTION
NOTE: Also refer to the latest comment by me down below for an update on this PR

This pull request adds a new page to represent a mockup schedule page.

The information of the page is hardcoded. Currently, the schedule page includes a header with the garden name, the owner, and the location, a section for stats, members, and plants being grown, and a section to include the garden's daily tasks with the option to select a date.

The schedule page can be accessed by going to  `.../page/schedule-page` . On the MVP, this page should be accessed whenever the user clicks on their desired garden.

As seen from the picture below, the toolbar does not contain the tabs intended for this project (these will be added in a different PR). 

![image](https://user-images.githubusercontent.com/55038687/86284171-97d90d80-bb9f-11ea-8a06-2aa1f7e35bd0.png)
