### PR TITLE
Return mock data from backend.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.google.sps</groupId>
-  <artifactId>portfolio</artifactId>
+  <groupId>com.google.growpod</groupId>
+  <artifactId>growpod</artifactId>
   <version>1</version>
   <packaging>war</packaging>
 

--- a/src/main/java/com/google/growpod/data/Garden.java
+++ b/src/main/java/com/google/growpod/data/Garden.java
@@ -1,0 +1,94 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.growpod.data;
+
+/** Garden data class. */
+public class Garden {
+
+  /** A unique id. */
+  private String id;
+
+  private String name;
+
+  /** Latitude of garden. */
+  private double lat;
+
+  /** Longitude of garden. */
+  private double lng;
+
+  /**
+   * Foreign Key to this garden's administrator. Currently, there is no checking as to whether this
+   * is a valid key.
+   */
+  private String adminId;
+
+  /**
+   * Constructs a new Garden.
+   *
+   * @param id A unique ID for the garden. This value must be supplied by the user.
+   * @param name The garden's name
+   * @param lat The garden's latitude
+   * @param lng The garden's longitude
+   * @param adminId The garden's administrator. THIS IS UNCHECKED.
+   */
+  public Garden(String id, String name, double lat, double lng, String adminId) {
+    this.id = id;
+    this.name = name;
+    this.lat = lat;
+    this.lng = lng;
+    this.adminId = adminId;
+  }
+
+  /* Getters and setters. */
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public double getLat() {
+    return lat;
+  }
+
+  public void setLat(double lat) {
+    this.lat = lat;
+  }
+
+  public double getLng() {
+    return lng;
+  }
+
+  public void setLng(double lng) {
+    this.lng = lng;
+  }
+
+  public String getAdminId() {
+    return adminId;
+  }
+
+  public void setAdminId(String id) {
+    this.adminId = id;
+  }
+}

--- a/src/main/java/com/google/growpod/data/Garden.java
+++ b/src/main/java/com/google/growpod/data/Garden.java
@@ -20,7 +20,7 @@ public class Garden {
   /** A unique id. */
   private String id;
 
-  /** The garden's name */
+  /** The garden's name. */
   private String name;
 
   /** Latitude of garden. */
@@ -29,9 +29,7 @@ public class Garden {
   /** Longitude of garden. */
   private double lng;
 
-  /**
-   * Foreign Key to this garden's administrator. Must be a valid user key.
-   */
+  /** Foreign Key to this garden's administrator. Must be a valid user key. */
   private String adminId;
 
   /**

--- a/src/main/java/com/google/growpod/data/Garden.java
+++ b/src/main/java/com/google/growpod/data/Garden.java
@@ -20,6 +20,7 @@ public class Garden {
   /** A unique id. */
   private String id;
 
+  /** The garden's name */
   private String name;
 
   /** Latitude of garden. */
@@ -29,8 +30,7 @@ public class Garden {
   private double lng;
 
   /**
-   * Foreign Key to this garden's administrator. Currently, there is no checking as to whether this
-   * is a valid key.
+   * Foreign Key to this garden's administrator. Must be a valid user key.
    */
   private String adminId;
 
@@ -41,7 +41,7 @@ public class Garden {
    * @param name The garden's name
    * @param lat The garden's latitude
    * @param lng The garden's longitude
-   * @param adminId The garden's administrator. THIS IS UNCHECKED.
+   * @param adminId The garden's administrator. Must be a valid user key.
    */
   public Garden(String id, String name, double lat, double lng, String adminId) {
     this.id = id;

--- a/src/main/java/com/google/growpod/data/Plant.java
+++ b/src/main/java/com/google/growpod/data/Plant.java
@@ -23,6 +23,7 @@ public class Plant {
   /** An optional nickname. */
   private String nickname;
 
+  /** The number of plants in this plot */
   private long count;
 
   /** Foreign Key to this plant's information. */

--- a/src/main/java/com/google/growpod/data/Plant.java
+++ b/src/main/java/com/google/growpod/data/Plant.java
@@ -35,7 +35,7 @@ public class Plant {
    * @param id A unique ID for the plant. This value must be supplied by the user.
    * @param nickname A nickname or null.
    * @param count The number of this type of plant.
-   * @param plantTypeId The garden's administrator. THIS IS UNCHECKED.
+   * @param plantTypeId The plant's type. Must be a valid plant type id.
    */
   public Plant(String id, String nickname, long count, String plantTypeId) {
     this.id = id;

--- a/src/main/java/com/google/growpod/data/Plant.java
+++ b/src/main/java/com/google/growpod/data/Plant.java
@@ -1,0 +1,88 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.growpod.data;
+
+/** Plant data class. */
+public class Plant {
+
+  /** A unique id. */
+  private String id;
+
+  /** An optional nickname. */
+  private String nickname;
+
+  private long count;
+
+  /** Foreign Key to this plant's information. */
+  private String plantTypeId;
+
+  /**
+   * Constructs a new Plant.
+   *
+   * @param id A unique ID for the plant. This value must be supplied by the user.
+   * @param nickname A nickname or null.
+   * @param count The number of this type of plant.
+   * @param plantTypeId The garden's administrator. THIS IS UNCHECKED.
+   */
+  public Plant(String id, String nickname, long count, String plantTypeId) {
+    this.id = id;
+    this.nickname = nickname;
+    this.count = count;
+    this.plantTypeId = plantTypeId;
+  }
+
+  /* Getters and setters. */
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  /**
+   * Gets the plant's nickname.
+   *
+   * @return the plant's nickname or null.
+   */
+  public String getNickname() {
+    return nickname;
+  }
+
+  /**
+   * Sets the plant's nickname.
+   *
+   * @param name the desired nickname or null.
+   */
+  public void setNickname(String name) {
+    this.nickname = name;
+  }
+
+  public long getCount() {
+    return count;
+  }
+
+  public void setCount(long count) {
+    this.count = count;
+  }
+
+  public String getPlantTypeId() {
+    return plantTypeId;
+  }
+
+  public void setPlantTypeId(String id) {
+    this.plantTypeId = id;
+  }
+}

--- a/src/main/java/com/google/growpod/data/Plant.java
+++ b/src/main/java/com/google/growpod/data/Plant.java
@@ -23,7 +23,7 @@ public class Plant {
   /** An optional nickname. */
   private String nickname;
 
-  /** The number of plants in this plot */
+  /** The number of plants in this plot. */
   private long count;
 
   /** Foreign Key to this plant's information. */

--- a/src/main/java/com/google/growpod/data/User.java
+++ b/src/main/java/com/google/growpod/data/User.java
@@ -29,8 +29,9 @@ public class User {
   private String biography;
   /**
    * We do not wish to keep exact user locations -- this will store some approximate location data.
+   * Unfortunately, this will only work in the US.
    */
-  private String coarseLocation;
+  private String zipCode;
 
   /**
    * Constructs a new User.
@@ -39,16 +40,15 @@ public class User {
    * @param email The user's email.
    * @param preferredName The user's preferred name.
    * @param biography A user-submitted biography truncated to MAX_BIOGRAPHY_LEN.
-   * @param coarseLocation The user's approximate location.
+   * @param zipCode The user's postal code.
    */
-  public User(
-      String id, String email, String preferredName, String biography, String coarseLocation) {
+  public User(String id, String email, String preferredName, String biography, String zipCode) {
     this.id = id;
     this.email = email;
     this.preferredName = preferredName;
     // Truncate biography
     this.biography = biography.substring(0, Math.min(biography.length(), MAX_BIOGRAPHY_LEN));
-    this.coarseLocation = coarseLocation;
+    this.zipCode = zipCode;
   }
 
   /* Getters and setters. */
@@ -95,11 +95,11 @@ public class User {
     this.biography = biography.substring(0, Math.min(biography.length(), MAX_BIOGRAPHY_LEN));
   }
 
-  public String getCoarseLocation() {
-    return coarseLocation;
+  public String getZipCode() {
+    return zipCode;
   }
 
-  public void setCoarseLocation(String location) {
-    this.coarseLocation = location;
+  public void setZipCode(String location) {
+    this.zipCode = location;
   }
 }

--- a/src/main/java/com/google/growpod/data/User.java
+++ b/src/main/java/com/google/growpod/data/User.java
@@ -14,13 +14,12 @@
 
 package com.google.growpod.data;
 
-
 /** User data class. */
 public class User {
 
   public static final int MAX_BIOGRAPHY_LEN = 160;
 
-  /** A unique id, encoded as a URL. */
+  /** A unique id. */
   private String id;
 
   private String email;

--- a/src/main/java/com/google/growpod/data/User.java
+++ b/src/main/java/com/google/growpod/data/User.java
@@ -20,13 +20,13 @@ public class User {
   /** A unique id. */
   private String id;
 
-  /** The user's primary email */
+  /** The user's primary email. */
   private String email;
 
   /** This is the only name we track. */
   private String preferredName;
 
-  /** The user's biography */
+  /** The user's biography. */
   private String biography;
 
   /**

--- a/src/main/java/com/google/growpod/data/User.java
+++ b/src/main/java/com/google/growpod/data/User.java
@@ -1,0 +1,106 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.growpod.data;
+
+
+/** User data class. */
+public class User {
+
+  public static final int MAX_BIOGRAPHY_LEN = 160;
+
+  /** A unique id, encoded as a URL. */
+  private String id;
+
+  private String email;
+  /** This is the only name we track. */
+  private String preferredName;
+
+  private String biography;
+  /**
+   * We do not wish to keep exact user locations -- this will store some approximate location data.
+   */
+  private String coarseLocation;
+
+  /**
+   * Constructs a new User.
+   *
+   * @param id A unique ID for the user. This value must be supplied by the user.
+   * @param email The user's email.
+   * @param preferredName The user's preferred name.
+   * @param biography A user-submitted biography truncated to MAX_BIOGRAPHY_LEN.
+   * @param coarseLocation The user's approximate location.
+   */
+  public User(
+      String id, String email, String preferredName, String biography, String coarseLocation) {
+    this.id = id;
+    this.email = email;
+    this.preferredName = preferredName;
+    // Truncate biography
+    this.biography = biography.substring(0, Math.min(biography.length(), MAX_BIOGRAPHY_LEN));
+    this.coarseLocation = coarseLocation;
+  }
+
+  /* Getters and setters. */
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getPreferredName() {
+    return preferredName;
+  }
+
+  public void setPreferredName(String name) {
+    this.preferredName = name;
+  }
+
+  /**
+   * Returns the user's biography. Guaranteed to be <= MAX_BIOGRAPHY_LEN in size.
+   *
+   * @return the user's biography.
+   */
+  public String getBiography() {
+    return biography;
+  }
+
+  /**
+   * Sets the user's biography to a new string and truncates it to MAX_BIOGRAPHY_LEN characters if
+   * applicable.
+   *
+   * @param biography the user's biography, to be truncated
+   */
+  public void setBiography(String biography) {
+    this.biography = biography.substring(0, Math.min(biography.length(), MAX_BIOGRAPHY_LEN));
+  }
+
+  public String getCoarseLocation() {
+    return coarseLocation;
+  }
+
+  public void setCoarseLocation(String location) {
+    this.coarseLocation = location;
+  }
+}

--- a/src/main/java/com/google/growpod/data/User.java
+++ b/src/main/java/com/google/growpod/data/User.java
@@ -17,16 +17,18 @@ package com.google.growpod.data;
 /** User data class. */
 public class User {
 
-  public static final int MAX_BIOGRAPHY_LEN = 160;
-
   /** A unique id. */
   private String id;
 
+  /** The user's primary email */
   private String email;
+
   /** This is the only name we track. */
   private String preferredName;
 
+  /** The user's biography */
   private String biography;
+
   /**
    * We do not wish to keep exact user locations -- this will store some approximate location data.
    * Unfortunately, this will only work in the US.
@@ -39,15 +41,14 @@ public class User {
    * @param id A unique ID for the user. This value must be supplied by the user.
    * @param email The user's email.
    * @param preferredName The user's preferred name.
-   * @param biography A user-submitted biography truncated to MAX_BIOGRAPHY_LEN.
+   * @param biography A user-submitted biography.
    * @param zipCode The user's postal code.
    */
   public User(String id, String email, String preferredName, String biography, String zipCode) {
     this.id = id;
     this.email = email;
     this.preferredName = preferredName;
-    // Truncate biography
-    this.biography = biography.substring(0, Math.min(biography.length(), MAX_BIOGRAPHY_LEN));
+    this.biography = biography;
     this.zipCode = zipCode;
   }
 
@@ -76,23 +77,12 @@ public class User {
     this.preferredName = name;
   }
 
-  /**
-   * Returns the user's biography. Guaranteed to be <= MAX_BIOGRAPHY_LEN in size.
-   *
-   * @return the user's biography.
-   */
   public String getBiography() {
     return biography;
   }
 
-  /**
-   * Sets the user's biography to a new string and truncates it to MAX_BIOGRAPHY_LEN characters if
-   * applicable.
-   *
-   * @param biography the user's biography, to be truncated
-   */
   public void setBiography(String biography) {
-    this.biography = biography.substring(0, Math.min(biography.length(), MAX_BIOGRAPHY_LEN));
+    this.biography = biography;
   }
 
   public String getZipCode() {

--- a/src/main/java/com/google/growpod/servlets/GardenServlet.java
+++ b/src/main/java/com/google/growpod/servlets/GardenServlet.java
@@ -1,0 +1,170 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.growpod.servlets;
+
+import com.google.gson.Gson;
+import com.google.growpod.data.Garden;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** 
+ * Servlet that handles garden entities on the server.
+ *
+ * API DOCUMENTATION:
+ *  /garden/{id}
+ *  {id} -- A garden UUID
+ *  GET: Retrieves the garden data structure for {id}
+ *  No parameters
+ *  Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ *  /garden/{id}/plant-list
+ *  {id} -- A garden UUID
+ *  GET: Retrieves all plants currently on {id} garden
+ *  No parameters
+ *  Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ *  /garden/{id}/user-list
+ *  {id} -- A garden UUID
+ *  GET: Retrieves all users currently on {id} garden
+ *  No parameters
+ *  Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ *
+ */
+@WebServlet({"/garden", "/garden/*"})
+public class GardenServlet extends HttpServlet {
+
+  static final long serialVersionUID = 1L;
+
+  /**
+   * Static test data.
+   */
+  private static final double newYorkLat = 40.82;
+  private static final double newYorkLng = -73.93;
+  private static final Map<String, Garden> GARDEN_MAP = createGardenMap();
+  private static Map<String, Garden> createGardenMap() {
+    Map<String, Garden> map = new HashMap<String, Garden>();
+    map.put("0", new Garden("0", "Flower Garden", newYorkLat, newYorkLng, "0"));
+    map.put("1", new Garden("1", "Pea Garden", newYorkLat, newYorkLng, "1"));
+    return Collections.unmodifiableMap(map);
+  }
+  private static final Map<String, List<String>> GARDEN_USER_LIST_MAP = createGardenUserListMap();
+  private static Map<String, List<String>> createGardenUserListMap() {
+    Map<String, List<String>> map = new HashMap<String, List<String>>();
+    map.put("0", Arrays.asList("0", "1"));
+    map.put("1", Arrays.asList("0", "1", "2"));
+    return Collections.unmodifiableMap(map);
+  }
+  private static final Map<String, List<String>> GARDEN_PLANT_LIST_MAP = createGardenPlantListMap();
+  private static Map<String, List<String>> createGardenPlantListMap() {
+    Map<String, List<String>> map = new HashMap<String, List<String>>();
+    map.put("0", Arrays.asList("0", "1"));
+    map.put("1", Arrays.asList("2", "3"));
+    return Collections.unmodifiableMap(map);
+  }
+
+  /**
+   * Processes HTTP GET requests for the /garden servlet. Dispatches functionality based on
+   * structure of GET request.
+   *
+   * @param request Information about the GET Request
+   * @param response Information about the servlet's response
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    /* uriList will have "" as element 0 */
+    String[] uriList = request.getRequestURI().split("/");
+    assert(uriList[1].equals("garden"));
+
+    // Dispatch based on method specified.
+    // /garden/{id}
+    if (uriList.length == 3) {
+      Garden garden = getGardenById(uriList[2]);
+      if (garden == null) {
+        response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid garden id: " + uriList[2]);
+        return;
+      }
+      response.setContentType("application/json;");
+      response.getWriter().println(new Gson().toJson(garden));
+      return;
+    }
+
+    if (uriList.length == 4) {
+      if (uriList[3].equals("user-list")) {
+        // /garden/{id}/user-list
+        List<String> list = getGardenUserListById(uriList[2]);
+        if (list == null) {
+          response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid garden id: " + uriList[2]);
+          return;
+        }
+        response.setContentType("application/json;");
+        response.getWriter().println(new Gson().toJson(list));
+        return;
+      } else if (uriList[3].equals("plant-list")) {
+        // /garden/{id}/plant-list
+        List<String> list = getGardenPlantListById(uriList[2]);
+        if (list == null) {
+          response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid garden id: " + uriList[2]);
+          return;
+        }
+        response.setContentType("application/json;");
+        response.getWriter().println(new Gson().toJson(list));
+        return;
+      }
+      // If the uriList does not match the above two methods, fall through.
+    }
+    response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
+  }
+
+  /**
+   * Retrieves a garden in the database by id, or null if said id does not exist.
+   *
+   * @param id the garden's id
+   * @return the garden with id's data or null.
+   */
+  private Garden getGardenById(String id) {
+    // MOCKUP IMPLEMENTATION
+    return GARDEN_MAP.get(id);
+  }
+
+  /**
+   * Retrieves a list of garden members.
+   * Returns null if the garden does not exist. 
+   *
+   * @param id the garden's id
+   * @return a list of user ids in the garden or null.
+   */
+  private List<String> getGardenUserListById(String id) {
+    // MOCKUP IMPLEMENTATION
+    return GARDEN_USER_LIST_MAP.get(id);
+  }
+
+  /**
+   * Retrieves a list of garden plants.
+   * Returns null if the garden does not exist. 
+   *
+   * @param id the garden's id
+   * @return a list of plant ids in the garden or null.
+   */
+  private List<String> getGardenPlantListById(String id) {
+    // MOCKUP IMPLEMENTATION
+    return GARDEN_PLANT_LIST_MAP.get(id);
+  }
+}

--- a/src/main/java/com/google/growpod/servlets/GardenServlet.java
+++ b/src/main/java/com/google/growpod/servlets/GardenServlet.java
@@ -14,65 +14,58 @@
 
 package com.google.growpod.servlets;
 
-import com.google.gson.Gson;
 import com.google.growpod.data.Garden;
+import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** 
+/**
  * Servlet that handles garden entities on the server.
  *
- * API DOCUMENTATION:
- *  /garden/{id}
- *  {id} -- A garden UUID
- *  GET: Retrieves the garden data structure for {id}
- *  No parameters
- *  Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
- *  /garden/{id}/plant-list
- *  {id} -- A garden UUID
- *  GET: Retrieves all plants currently on {id} garden
- *  No parameters
- *  Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
- *  /garden/{id}/user-list
- *  {id} -- A garden UUID
- *  GET: Retrieves all users currently on {id} garden
- *  No parameters
- *  Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
- *
+ * <p>API DOCUMENTATION: /garden/{id} {id} -- A garden UUID GET: Retrieves the garden data structure
+ * for {id} No parameters Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ * /garden/{id}/plant-list {id} -- A garden UUID GET: Retrieves all plants currently on {id} garden
+ * No parameters Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ * /garden/{id}/user-list {id} -- A garden UUID GET: Retrieves all users currently on {id} garden No
+ * parameters Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
  */
 @WebServlet({"/garden", "/garden/*"})
 public class GardenServlet extends HttpServlet {
 
   static final long serialVersionUID = 1L;
 
-  /**
-   * Static test data.
-   */
+  /** Static test data. */
   private static final double newYorkLat = 40.82;
+
   private static final double newYorkLng = -73.93;
   private static final Map<String, Garden> GARDEN_MAP = createGardenMap();
+
   private static Map<String, Garden> createGardenMap() {
     Map<String, Garden> map = new HashMap<String, Garden>();
     map.put("0", new Garden("0", "Flower Garden", newYorkLat, newYorkLng, "0"));
     map.put("1", new Garden("1", "Pea Garden", newYorkLat, newYorkLng, "1"));
     return Collections.unmodifiableMap(map);
   }
+
   private static final Map<String, List<String>> GARDEN_USER_LIST_MAP = createGardenUserListMap();
+
   private static Map<String, List<String>> createGardenUserListMap() {
     Map<String, List<String>> map = new HashMap<String, List<String>>();
     map.put("0", Arrays.asList("0", "1"));
     map.put("1", Arrays.asList("0", "1", "2"));
     return Collections.unmodifiableMap(map);
   }
+
   private static final Map<String, List<String>> GARDEN_PLANT_LIST_MAP = createGardenPlantListMap();
+
   private static Map<String, List<String>> createGardenPlantListMap() {
     Map<String, List<String>> map = new HashMap<String, List<String>>();
     map.put("0", Arrays.asList("0", "1"));
@@ -91,7 +84,7 @@ public class GardenServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     /* uriList will have "" as element 0 */
     String[] uriList = request.getRequestURI().split("/");
-    assert(uriList[1].equals("garden"));
+    assert (uriList[1].equals("garden"));
 
     // Dispatch based on method specified.
     // /garden/{id}
@@ -130,7 +123,8 @@ public class GardenServlet extends HttpServlet {
       }
       // If the uriList does not match the above two methods, fall through.
     }
-    response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
+    response.sendError(
+        HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
   }
 
   /**
@@ -145,8 +139,7 @@ public class GardenServlet extends HttpServlet {
   }
 
   /**
-   * Retrieves a list of garden members.
-   * Returns null if the garden does not exist. 
+   * Retrieves a list of garden members. Returns null if the garden does not exist.
    *
    * @param id the garden's id
    * @return a list of user ids in the garden or null.
@@ -157,8 +150,7 @@ public class GardenServlet extends HttpServlet {
   }
 
   /**
-   * Retrieves a list of garden plants.
-   * Returns null if the garden does not exist. 
+   * Retrieves a list of garden plants. Returns null if the garden does not exist.
    *
    * @param id the garden's id
    * @return a list of plant ids in the garden or null.

--- a/src/main/java/com/google/growpod/servlets/PageServlet.java
+++ b/src/main/java/com/google/growpod/servlets/PageServlet.java
@@ -12,30 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.sps.servlets;
+package com.google.growpod.servlets;
 
 import java.io.IOException;
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that sends a sample response. */
-@WebServlet("/test")
-public class TestServlet extends HttpServlet {
+/** Servlet that returns index.html */
+@WebServlet("/page/*")
+public class PageServlet extends HttpServlet {
 
-  static final long serialVersionUID = 1L;
+  static final long serialVersionUID = 2L;
 
   /**
-   * Processes HTTP GET requests for the /test servlet. Returns a test response -- a very simple
-   * JSON structure with 'status' and 'value' fields.
+   * Processes HTTP GET requests for the /page/* servlet. This returns index.html, and allows client
+   * side routing to show the appropriate client page.
    *
    * @param request Information about the GET Request
    * @param response Information about the servlet's response
    */
   @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("application/json;");
-    response.getWriter().println("{ \"status\": \"ok\", \"value\": \"test\" }");
+  public void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+    response.setContentType("text/html;");
+    request.getRequestDispatcher("/index.html").forward(request, response);
   }
 }

--- a/src/main/java/com/google/growpod/servlets/PlantServlet.java
+++ b/src/main/java/com/google/growpod/servlets/PlantServlet.java
@@ -14,38 +14,31 @@
 
 package com.google.growpod.servlets;
 
-import com.google.gson.Gson;
 import com.google.growpod.data.Plant;
+import com.google.gson.Gson;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Map;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** 
+/**
  * Servlet that handles plant entities on the server.
  *
- * API DOCUMENTATION:
- *  /plant/{id}
- *  {id} -- A plant UUID
- *  GET: Retrieves the plant data structure for {id}
- *  No parameters
- *  Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ * <p>API DOCUMENTATION: /plant/{id} {id} -- A plant UUID GET: Retrieves the plant data structure
+ * for {id} No parameters Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
  */
 @WebServlet({"/plant", "/plant/*"})
 public class PlantServlet extends HttpServlet {
 
   static final long serialVersionUID = 1L;
 
-  /**
-   * Static test data.
-   */
+  /** Static test data. */
   private static final Map<String, Plant> PLANT_MAP = createPlantMap();
+
   private static Map<String, Plant> createPlantMap() {
     Map<String, Plant> map = new HashMap<String, Plant>();
     map.put("0", new Plant("0", "Flower Plant 1", 4, "0"));
@@ -56,8 +49,8 @@ public class PlantServlet extends HttpServlet {
   }
 
   /**
-   * Processes HTTP GET requests for the /plant servlet. Dispatches functionality based on
-   * structure of GET request.
+   * Processes HTTP GET requests for the /plant servlet. Dispatches functionality based on structure
+   * of GET request.
    *
    * @param request Information about the GET Request
    * @param response Information about the servlet's response
@@ -66,7 +59,7 @@ public class PlantServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     /* uriList will have "" as element 0 */
     String[] uriList = request.getRequestURI().split("/");
-    assert(uriList[1].equals("plant"));
+    assert (uriList[1].equals("plant"));
 
     // Dispatch based on method specified.
     // /plant/{id}
@@ -81,7 +74,8 @@ public class PlantServlet extends HttpServlet {
       return;
     }
 
-    response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
+    response.sendError(
+        HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
   }
 
   /**

--- a/src/main/java/com/google/growpod/servlets/PlantServlet.java
+++ b/src/main/java/com/google/growpod/servlets/PlantServlet.java
@@ -1,0 +1,97 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.growpod.servlets;
+
+import com.google.gson.Gson;
+import com.google.growpod.data.Plant;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** 
+ * Servlet that handles plant entities on the server.
+ *
+ * API DOCUMENTATION:
+ *  /plant/{id}
+ *  {id} -- A plant UUID
+ *  GET: Retrieves the plant data structure for {id}
+ *  No parameters
+ *  Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ */
+@WebServlet({"/plant", "/plant/*"})
+public class PlantServlet extends HttpServlet {
+
+  static final long serialVersionUID = 1L;
+
+  /**
+   * Static test data.
+   */
+  private static final Map<String, Plant> PLANT_MAP = createPlantMap();
+  private static Map<String, Plant> createPlantMap() {
+    Map<String, Plant> map = new HashMap<String, Plant>();
+    map.put("0", new Plant("0", "Flower Plant 1", 4, "0"));
+    map.put("1", new Plant("1", "Flower Plant 2", 4, "1"));
+    map.put("2", new Plant("2", "Pea Plant 1", 4, "2"));
+    map.put("3", new Plant("3", "Pea Plant 2", 4, "3"));
+    return Collections.unmodifiableMap(map);
+  }
+
+  /**
+   * Processes HTTP GET requests for the /plant servlet. Dispatches functionality based on
+   * structure of GET request.
+   *
+   * @param request Information about the GET Request
+   * @param response Information about the servlet's response
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    /* uriList will have "" as element 0 */
+    String[] uriList = request.getRequestURI().split("/");
+    assert(uriList[1].equals("plant"));
+
+    // Dispatch based on method specified.
+    // /plant/{id}
+    if (uriList.length == 3) {
+      Plant plant = getPlantById(uriList[2]);
+      if (plant == null) {
+        response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid plant id: " + uriList[2]);
+        return;
+      }
+      response.setContentType("application/json;");
+      response.getWriter().println(new Gson().toJson(plant));
+      return;
+    }
+
+    response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
+  }
+
+  /**
+   * Retrieves a plant in the database by id, or null if said id does not exist.
+   *
+   * @param id the plant's id
+   * @return the plant with id's data or null.
+   */
+  private Plant getPlantById(String id) {
+    // MOCKUP IMPLEMENTATION
+    return PLANT_MAP.get(id);
+  }
+}

--- a/src/main/java/com/google/growpod/servlets/TestServlet.java
+++ b/src/main/java/com/google/growpod/servlets/TestServlet.java
@@ -12,32 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.sps.servlets;
+package com.google.growpod.servlets;
 
 import java.io.IOException;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that returns index.html */
-@WebServlet("/page/*")
-public class PageServlet extends HttpServlet {
+/** Servlet that sends a sample response. */
+@WebServlet("/test")
+public class TestServlet extends HttpServlet {
 
-  static final long serialVersionUID = 2L;
+  static final long serialVersionUID = 1L;
 
   /**
-   * Processes HTTP GET requests for the /page/* servlet. This returns index.html, and allows client
-   * side routing to show the appropriate client page.
+   * Processes HTTP GET requests for the /test servlet. Returns a test response -- a very simple
+   * JSON structure with 'status' and 'value' fields.
    *
    * @param request Information about the GET Request
    * @param response Information about the servlet's response
    */
   @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response)
-      throws ServletException, IOException {
-    response.setContentType("text/html;");
-    request.getRequestDispatcher("/index.html").forward(request, response);
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    response.setContentType("application/json;");
+    response.getWriter().println("{ \"status\": \"ok\", \"value\": \"test\" }");
   }
 }

--- a/src/main/java/com/google/growpod/servlets/UserServlet.java
+++ b/src/main/java/com/google/growpod/servlets/UserServlet.java
@@ -1,0 +1,139 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.growpod.servlets;
+
+import com.google.gson.Gson;
+import com.google.growpod.data.User;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** 
+ * Servlet that handles user entities on the server.
+ *
+ * API DOCUMENTATION:
+ * /user/{id}
+ *  - {id} -- A user id, or `current` for the logged in user
+ * GET: Retrieves the user data structure for {id}
+ *  - No parameters
+ *  - Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ * /user/{id}/garden-list
+ *  - {id} -- A user id, or `current` for the logged in user
+ * GET: Retrieves the list of gardens user {id} is a member of
+ *  - No parameters
+ *  - Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ */
+@WebServlet({"/user", "/user/*"})
+public class UserServlet extends HttpServlet {
+
+  static final long serialVersionUID = 1L;
+
+  /**
+   * Static test data.
+   */
+  private static final String CURRENT_USER_KEY = "0";
+  private static final Map<String, User> USER_MAP = createUserMap();
+  private static Map<String, User> createUserMap() {
+    Map<String, User> map = new HashMap<String, User>();
+    map.put("0", new User("0", "ladd@example.com", "David Ladd", "My SSN is: 143-46-6098", "New York, NY"));
+    map.put("1", new User("1", "caroqliu@google.com", "Caroline Liu", "Plants are fun", "New York, NY"));
+    map.put("2", new User("2", "friedj@google.com", "Jake Fried", "Plants are fun too", "New York, NY"));
+    return Collections.unmodifiableMap(map);
+  }
+  private static final Map<String, List<String>> USER_GARDEN_LIST_MAP = createUserGardenListMap();
+  private static Map<String, List<String>> createUserGardenListMap() {
+    Map<String, List<String>> map = new HashMap<String, List<String>>();
+    map.put("0", Arrays.asList("0", "1"));
+    map.put("1", Arrays.asList("1"));
+    map.put("2", Arrays.asList("1"));
+    return Collections.unmodifiableMap(map);
+  }
+
+  /**
+   * Processes HTTP GET requests for the /user servlet. Dispatches functionality based on
+   * structure of GET request.
+   *
+   * @param request Information about the GET Request
+   * @param response Information about the servlet's response
+   */
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    /* uriList will have "" as element 0 */
+    String[] uriList = request.getRequestURI().split("/");
+    assert(uriList[1].equals("user"));
+
+    // Dispatch based on method specified.
+    // /user/{id}
+    if (uriList.length == 3) {
+      User user = getUserById(uriList[2]);
+      if (user == null) {
+        response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid user id: " + uriList[2]);
+        return;
+      }
+      response.setContentType("application/json;");
+      response.getWriter().println(new Gson().toJson(user));
+      return;
+    }
+
+    // /user/{id}/garden-list
+    if (uriList.length == 4) {
+      List<String> list = getUserGardenListById(uriList[2]);
+      if (list == null) {
+        response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid user id: " + uriList[2]);
+        return;
+      }
+      response.setContentType("application/json;");
+      response.getWriter().println(new Gson().toJson(list));
+      return;
+    }
+    response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
+  }
+
+  /**
+   * Retrieves a user in the database by id, or null if said id does not exist.
+   *
+   * @param id the user's id
+   * @return the user with id's data or null.
+   */
+  private User getUserById(String id) {
+    // MOCKUP IMPLEMENTATION
+    if (id.equals("current"))
+      return USER_MAP.get(CURRENT_USER_KEY);
+    return USER_MAP.get(id);
+  }
+
+  /**
+   * Retrieves a list of gardens the user with a given id is a member of. 
+   * Returns an empty list if the user is a member of no gardens, and null
+   * if the user does not exist.
+   *
+   * @param id the user's id
+   * @return a list of gardens the user is a part of, or an empty list, or
+   * null.
+   */
+  private List<String> getUserGardenListById(String id) {
+    // MOCKUP IMPLEMENTATION
+    if (id.equals("current"))
+      return USER_GARDEN_LIST_MAP.get(CURRENT_USER_KEY);
+    return USER_GARDEN_LIST_MAP.get(id);
+  }
+}

--- a/src/main/java/com/google/growpod/servlets/UserServlet.java
+++ b/src/main/java/com/google/growpod/servlets/UserServlet.java
@@ -14,52 +14,54 @@
 
 package com.google.growpod.servlets;
 
-import com.google.gson.Gson;
 import com.google.growpod.data.User;
+import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** 
+/**
  * Servlet that handles user entities on the server.
  *
- * API DOCUMENTATION:
- * /user/{id}
- *  - {id} -- A user id, or `current` for the logged in user
- * GET: Retrieves the user data structure for {id}
- *  - No parameters
- *  - Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
- * /user/{id}/garden-list
- *  - {id} -- A user id, or `current` for the logged in user
- * GET: Retrieves the list of gardens user {id} is a member of
- *  - No parameters
- *  - Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
+ * <p>API DOCUMENTATION: /user/{id} - {id} -- A user id, or `current` for the logged in user GET:
+ * Retrieves the user data structure for {id} - No parameters - Returns data in JSON format along
+ * with (200 OK), otherwise (404 NOT FOUND) /user/{id}/garden-list - {id} -- A user id, or `current`
+ * for the logged in user GET: Retrieves the list of gardens user {id} is a member of - No
+ * parameters - Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
  */
 @WebServlet({"/user", "/user/*"})
 public class UserServlet extends HttpServlet {
 
   static final long serialVersionUID = 1L;
 
-  /**
-   * Static test data.
-   */
+  /** Static test data. */
   private static final String CURRENT_USER_KEY = "0";
+
   private static final Map<String, User> USER_MAP = createUserMap();
+
   private static Map<String, User> createUserMap() {
     Map<String, User> map = new HashMap<String, User>();
-    map.put("0", new User("0", "ladd@example.com", "David Ladd", "My SSN is: 143-46-6098", "New York, NY"));
-    map.put("1", new User("1", "caroqliu@google.com", "Caroline Liu", "Plants are fun", "New York, NY"));
-    map.put("2", new User("2", "friedj@google.com", "Jake Fried", "Plants are fun too", "New York, NY"));
+    map.put(
+        "0",
+        new User("0", "ladd@example.com", "David Ladd", "My SSN is: 143-46-6098", "New York, NY"));
+    map.put(
+        "1",
+        new User("1", "caroqliu@google.com", "Caroline Liu", "Plants are fun", "New York, NY"));
+    map.put(
+        "2",
+        new User("2", "friedj@google.com", "Jake Fried", "Plants are fun too", "New York, NY"));
     return Collections.unmodifiableMap(map);
   }
+
   private static final Map<String, List<String>> USER_GARDEN_LIST_MAP = createUserGardenListMap();
+
   private static Map<String, List<String>> createUserGardenListMap() {
     Map<String, List<String>> map = new HashMap<String, List<String>>();
     map.put("0", Arrays.asList("0", "1"));
@@ -69,8 +71,8 @@ public class UserServlet extends HttpServlet {
   }
 
   /**
-   * Processes HTTP GET requests for the /user servlet. Dispatches functionality based on
-   * structure of GET request.
+   * Processes HTTP GET requests for the /user servlet. Dispatches functionality based on structure
+   * of GET request.
    *
    * @param request Information about the GET Request
    * @param response Information about the servlet's response
@@ -79,7 +81,7 @@ public class UserServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     /* uriList will have "" as element 0 */
     String[] uriList = request.getRequestURI().split("/");
-    assert(uriList[1].equals("user"));
+    assert (uriList[1].equals("user"));
 
     // Dispatch based on method specified.
     // /user/{id}
@@ -105,7 +107,8 @@ public class UserServlet extends HttpServlet {
       response.getWriter().println(new Gson().toJson(list));
       return;
     }
-    response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
+    response.sendError(
+        HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
   }
 
   /**
@@ -116,24 +119,24 @@ public class UserServlet extends HttpServlet {
    */
   private User getUserById(String id) {
     // MOCKUP IMPLEMENTATION
-    if (id.equals("current"))
+    if (id.equals("current")) {
       return USER_MAP.get(CURRENT_USER_KEY);
+    }
     return USER_MAP.get(id);
   }
 
   /**
-   * Retrieves a list of gardens the user with a given id is a member of. 
-   * Returns an empty list if the user is a member of no gardens, and null
-   * if the user does not exist.
+   * Retrieves a list of gardens the user with a given id is a member of. Returns an empty list if
+   * the user is a member of no gardens, and null if the user does not exist.
    *
    * @param id the user's id
-   * @return a list of gardens the user is a part of, or an empty list, or
-   * null.
+   * @return a list of gardens the user is a part of, or an empty list, or null.
    */
   private List<String> getUserGardenListById(String id) {
     // MOCKUP IMPLEMENTATION
-    if (id.equals("current"))
+    if (id.equals("current")) {
       return USER_GARDEN_LIST_MAP.get(CURRENT_USER_KEY);
+    }
     return USER_GARDEN_LIST_MAP.get(id);
   }
 }

--- a/src/main/java/com/google/growpod/servlets/UserServlet.java
+++ b/src/main/java/com/google/growpod/servlets/UserServlet.java
@@ -49,14 +49,9 @@ public class UserServlet extends HttpServlet {
   private static Map<String, User> createUserMap() {
     Map<String, User> map = new HashMap<String, User>();
     map.put(
-        "0",
-        new User("0", "ladd@example.com", "David Ladd", "My SSN is: 143-46-6098", "New York, NY"));
-    map.put(
-        "1",
-        new User("1", "caroqliu@google.com", "Caroline Liu", "Plants are fun", "New York, NY"));
-    map.put(
-        "2",
-        new User("2", "friedj@google.com", "Jake Fried", "Plants are fun too", "New York, NY"));
+        "0", new User("0", "ladd@example.com", "David Ladd", "My SSN is: 143-46-6098", "11201"));
+    map.put("1", new User("1", "caroqliu@google.com", "Caroline Liu", "Plants are fun", "11201"));
+    map.put("2", new User("2", "friedj@google.com", "Jake Fried", "Plants are fun too", "11201"));
     return Collections.unmodifiableMap(map);
   }
 


### PR DESCRIPTION
I have rebased my work on `master`.

This is a simple backend which conforms to the API in the design doc. All the methods which return an object return a JSON object that corresponds to the partial class declarations in the design document. All the methods which return a list, like `GET: /garden/{id}/user-list`, return a JSON array of ids, which can then be used in other server requests.

Right now, the only operations implemented are `GET` operations, and no persistent storage solution is used.

Example: `GET: /user/0` returns
```
{"id":"0","email":"ladd@example.com","preferredName":"David Ladd","biography":"My SSN is: 143-46-6098","coarseLocation":"New York, NY"}
```

Note: `/user/current` returns `/user/0` right now, but will eventually return the logged in user.