### PR TITLE
Administer Page

### DIFF
--- a/src/main/java/com/google/growpod/controllers/GardenDao.java
+++ b/src/main/java/com/google/growpod/controllers/GardenDao.java
@@ -136,6 +136,7 @@ public class GardenDao {
         Query.newEntityQueryBuilder()
             .setKind("HasMember")
             .setFilter(PropertyFilter.eq("garden-id", gardenId))
+            .setFilter(PropertyFilter.eq("user-id", userId))
             .build();
     QueryResults<Entity> results = datastore.run(query);
     if (!results.hasNext()) {
@@ -166,6 +167,7 @@ public class GardenDao {
         Query.newEntityQueryBuilder()
             .setKind("ContainsPlant")
             .setFilter(PropertyFilter.eq("garden-id", gardenId))
+            .setFilter(PropertyFilter.eq("plant-id", plantId))
             .build();
     QueryResults<Entity> results = datastore.run(query);
     if (!results.hasNext()) {

--- a/src/main/java/com/google/growpod/controllers/GardenDao.java
+++ b/src/main/java/com/google/growpod/controllers/GardenDao.java
@@ -125,11 +125,11 @@ public class GardenDao {
    *
    * @param gardenId the garden to add the plant to
    * @param plant the plant object
-   * @return Whether the addition was successful
+   * @return The plant's key
    */
-  public boolean addToGardenPlantList(String gardenId, Plant plant) {
+  public String addToGardenPlantList(String gardenId, Plant plant) {
     // Add plant to plant list first
-    plant.setId("0"); // Dummy key to make .toEntity(datastoreInstance) work.
+    plant.setId("1"); // Dummy key to make .toEntity(datastoreInstance) work.
     KeyFactory keyFactory = datastore.newKeyFactory().setKind("Plant");
     IncompleteKey incompleteKey = keyFactory.newKey();
 
@@ -141,16 +141,15 @@ public class GardenDao {
     String plantId = Long.toString(newEntity.getKey().getId());
 
     // Then add relation
-    ContainsPlant relation = new ContainsPlant("0", gardenId, plantId);
-
     keyFactory = datastore.newKeyFactory().setKind("ContainsPlant");
     incompleteKey = keyFactory.newKey();
 
     key = datastore.allocateId(incompleteKey);
+    ContainsPlant relation = new ContainsPlant("1", gardenId, plantId);
 
     newEntity = Entity.newBuilder(key, relation.toEntity(datastoreInstance)).build();
     datastore.add(newEntity);
-    return true;
+    return plantId;
   }
 
   /**

--- a/src/main/java/com/google/growpod/servlets/GardenServlet.java
+++ b/src/main/java/com/google/growpod/servlets/GardenServlet.java
@@ -126,11 +126,18 @@ public class GardenServlet extends HttpServlet {
         // TODO (Issue #34) Verify user
         String jsonString = getBody(request);
         Plant plant = new Gson().fromJson(jsonString, Plant.class);
-        String key = dao.addToGardenPlantList(uriList[2], plant);
-        if (key == null) {
-          response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+        Garden garden = dao.getGardenById(uriList[2]);
+        if (garden == null) {
+          response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid garden id: " + uriList[2]);
           return;
         }
+        String key = dao.addToGardenPlantList(uriList[2], plant);
+        if (key == null) {
+          response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid user body");
+          return;
+        }
+
+        response.setStatus(HttpServletResponse.SC_CREATED);
         response.setContentType("application/json;");
         response.getWriter().println("{\"id\":" + key + "}");
         return;
@@ -169,7 +176,7 @@ public class GardenServlet extends HttpServlet {
         boolean status = dao.deleteFromGardenUserList(uriList[2], uriList[4]);
         if (!status) {
           // Nothing to delete
-          response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+          response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid user: " + uriList[4] + " of garden: " + uriList[2]);
           return;
         }
         response.setContentType("application/json;");
@@ -179,7 +186,7 @@ public class GardenServlet extends HttpServlet {
         // /garden/{gid}/plant-list/{pid}
         boolean status = dao.deleteFromGardenPlantList(uriList[2], uriList[4]);
         if (!status) {
-          response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+          response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid plant: " + uriList[4] + " of garden: " + uriList[2]);
           return;
         }
         response.setContentType("application/json;");

--- a/src/main/java/com/google/growpod/servlets/GardenServlet.java
+++ b/src/main/java/com/google/growpod/servlets/GardenServlet.java
@@ -176,7 +176,9 @@ public class GardenServlet extends HttpServlet {
         boolean status = dao.deleteFromGardenUserList(uriList[2], uriList[4]);
         if (!status) {
           // Nothing to delete
-          response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid user: " + uriList[4] + " of garden: " + uriList[2]);
+          response.sendError(
+              HttpServletResponse.SC_NOT_FOUND,
+              "Invalid user: " + uriList[4] + " of garden: " + uriList[2]);
           return;
         }
         response.setContentType("application/json;");
@@ -186,7 +188,9 @@ public class GardenServlet extends HttpServlet {
         // /garden/{gid}/plant-list/{pid}
         boolean status = dao.deleteFromGardenPlantList(uriList[2], uriList[4]);
         if (!status) {
-          response.sendError(HttpServletResponse.SC_NOT_FOUND, "Invalid plant: " + uriList[4] + " of garden: " + uriList[2]);
+          response.sendError(
+              HttpServletResponse.SC_NOT_FOUND,
+              "Invalid plant: " + uriList[4] + " of garden: " + uriList[2]);
           return;
         }
         response.setContentType("application/json;");

--- a/src/main/java/com/google/growpod/servlets/GardenServlet.java
+++ b/src/main/java/com/google/growpod/servlets/GardenServlet.java
@@ -29,12 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Servlet that handles garden entities on the server.
  *
- * <p>API DOCUMENTATION: /garden/{id} {id} -- A garden UUID GET: Retrieves the garden data structure
- * for {id} No parameters Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
- * /garden/{id}/plant-list {id} -- A garden UUID GET: Retrieves all plants currently on {id} garden
- * No parameters Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
- * /garden/{id}/user-list {id} -- A garden UUID GET: Retrieves all users currently on {id} garden No
- * parameters Returns data in JSON format along with (200 OK), otherwise (404 NOT FOUND)
  */
 @WebServlet({"/garden", "/garden/*"})
 public class GardenServlet extends HttpServlet {
@@ -106,6 +100,57 @@ public class GardenServlet extends HttpServlet {
     response.sendError(
         HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
   }
+
+  /**
+   * Processes HTTP DELETE requests for the /garden servlet. Dispatches functionality based on
+   * structure of DELETE request.
+   *
+   * @param request Information about the GET Request
+   * @param response Information about the servlet's response
+   */
+  @Override
+  public void doDelete(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    /* uriList will have "" as element 0 */
+    String[] uriList = request.getRequestURI().split("/");
+    assert (uriList[1].equals("garden"));
+
+    // Dispatch based on method specified.
+    // /garden/{id}
+    if (uriList.length == 3) {
+      // TODO Delete garden provided owner is current user.
+      return;
+    }
+
+    if (uriList.length == 5) {
+      if (uriList[3].equals(USER_LIST_ARG)) {
+        // /garden/{gid}/user-list/{uid}
+        // TODO (Issue #34) Verify user
+        boolean status = dao.deleteFromGardenUserList(uriList[2], uriList[4]);
+        if (!status) {
+          // Nothing to delete
+          response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+          return;
+        }
+        response.setContentType("application/json;");
+        response.getWriter().println("{\"id\":" + uriList[4] + "}");
+        return;
+      } else if (uriList[3].equals(PLANT_LIST_ARG)) {
+        // /garden/{gid}/plant-list/{pid}
+        boolean status = dao.deleteFromGardenPlantList(uriList[2], uriList[4]);
+        if (!status) {
+          response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+          return;
+        }
+        response.setContentType("application/json;");
+        response.getWriter().println("{\"id\":" + uriList[4] + "}");
+        return;
+      }
+      // If the uriList does not match the above two methods, fall through.
+    }
+    response.sendError(
+        HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
+  }
+
 
   /** Getters and Setters for data access object. */
   public GardenDao getDao() {

--- a/src/main/java/com/google/growpod/servlets/GardenServlet.java
+++ b/src/main/java/com/google/growpod/servlets/GardenServlet.java
@@ -26,10 +26,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/**
- * Servlet that handles garden entities on the server.
- *
- */
+/** Servlet that handles garden entities on the server. */
 @WebServlet({"/garden", "/garden/*"})
 public class GardenServlet extends HttpServlet {
 
@@ -109,7 +106,8 @@ public class GardenServlet extends HttpServlet {
    * @param response Information about the servlet's response
    */
   @Override
-  public void doDelete(HttpServletRequest request, HttpServletResponse response) throws IOException {
+  public void doDelete(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
     /* uriList will have "" as element 0 */
     String[] uriList = request.getRequestURI().split("/");
     assert (uriList[1].equals("garden"));
@@ -150,7 +148,6 @@ public class GardenServlet extends HttpServlet {
     response.sendError(
         HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Unimplemented: " + request.getRequestURI());
   }
-
 
   /** Getters and Setters for data access object. */
   public GardenDao getDao() {

--- a/src/main/java/com/google/growpod/servlets/GardenServlet.java
+++ b/src/main/java/com/google/growpod/servlets/GardenServlet.java
@@ -21,7 +21,6 @@ import com.google.growpod.data.Plant;
 import com.google.gson.Gson;
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.lang.StringBuilder;
 import java.util.List;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -109,8 +108,7 @@ public class GardenServlet extends HttpServlet {
    * @param response Information about the servlet's response
    */
   @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response)
-      throws IOException {
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     /* uriList will have "" as element 0 */
     String[] uriList = request.getRequestURI().split("/");
     assert (uriList[1].equals("garden"));
@@ -128,13 +126,13 @@ public class GardenServlet extends HttpServlet {
         // TODO (Issue #34) Verify user
         String jsonString = getBody(request);
         Plant plant = new Gson().fromJson(jsonString, Plant.class);
-        boolean status = dao.addToGardenPlantList(uriList[2], plant);
-        if (!status) {
+        String key = dao.addToGardenPlantList(uriList[2], plant);
+        if (key == null) {
           response.setStatus(HttpServletResponse.SC_NO_CONTENT);
           return;
         }
         response.setContentType("application/json;");
-        response.getWriter().println("{\"id\":" + uriList[4] + "}");
+        response.getWriter().println("{\"id\":" + key + "}");
         return;
       }
       // If the uriList does not match the above two methods, fall through.
@@ -205,7 +203,7 @@ public class GardenServlet extends HttpServlet {
 
   /**
    * Reads POST request body into string.
-   * 
+   *
    * @param request Http Servlet Request.
    * @return The request body.
    */

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.css
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.css
@@ -7,5 +7,5 @@
 }
 
 .add-plant-form-table {
-  margin-top: 64px; 
+  margin-top: 64px;
 }

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.css
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.css
@@ -1,0 +1,11 @@
+.form {
+  background-color: #00bb98;
+  max-height: 450px;
+  max-width: 400px;
+  margin: 20px auto;
+  text-align: center;
+}
+
+.add-plant-form-table {
+  margin-top: 64px; 
+}

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
@@ -24,8 +24,8 @@
     <mat-error
       *ngIf="
         plantGroup.controls.count.hasError('required') ||
-        plantGroup.controls.nickname.hasError('pattern') ||
-        plantGroup.controls.nickname.hasError('min')
+        plantGroup.controls.count.hasError('pattern') ||
+        plantGroup.controls.count.hasError('min')
       "
     >
       Number of plants is <strong>required</strong> and must be a positive

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
@@ -1,4 +1,3 @@
-
 <h2 mat-dialog-title>
   Add Plant
 </h2>
@@ -6,19 +5,31 @@
 <form [formGroup]="plantGroup">
   <mat-form-field class="div-center">
     <mat-label>Plant Nickname</mat-label>
-    <input formControlName="nickname" matInput placeholder="Enter a name">
-    <mat-error *ngIf="plantGroup.controls.nickname.hasError('required') || plantGroup.controls.nickname.hasError('minLength')">
+    <input formControlName="nickname" matInput placeholder="Enter a name" />
+    <mat-error
+      *ngIf="
+        plantGroup.controls.nickname.hasError('required') ||
+        plantGroup.controls.nickname.hasError('minLength')
+      "
+    >
       Nickname is <strong>required</strong>
     </mat-error>
   </mat-form-field>
-  
+
   <br />
 
   <mat-form-field class="div-center">
     <mat-label>Number of Plants</mat-label>
-    <input formControlName="count" matInput placeholder="Enter a number">
-     <mat-error *ngIf="plantGroup.controls.count.hasError('required') || plantGroup.controls.nickname.hasError('pattern') || plantGroup.controls.nickname.hasError('min')">
-      Number of plants is <strong>required</strong> and must be a positive number.
+    <input formControlName="count" matInput placeholder="Enter a number" />
+    <mat-error
+      *ngIf="
+        plantGroup.controls.count.hasError('required') ||
+        plantGroup.controls.nickname.hasError('pattern') ||
+        plantGroup.controls.nickname.hasError('min')
+      "
+    >
+      Number of plants is <strong>required</strong> and must be a positive
+      number.
     </mat-error>
   </mat-form-field>
 </form>
@@ -26,7 +37,8 @@
 <table class="add-plant-form-table">
   <tr>
     <td><button mat-button class="button" (click)="close()">Cancel</button></td>
-    <td><button mat-button class="button" (click)="submit()">Add Plant</button></td>
+    <td>
+      <button mat-button class="button" (click)="submit()">Add Plant</button>
+    </td>
   </tr>
 </table>
-

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
@@ -1,0 +1,32 @@
+
+<h2 mat-dialog-title>
+  Add Plant
+</h2>
+
+<form [formGroup]="plantGroup">
+  <mat-form-field class="div-center">
+    <mat-label>Plant Nickname</mat-label>
+    <input formControlName="nickname" matInput placeholder="Enter a name">
+    <mat-error *ngIf="plantGroup.controls.nickname.hasError('required') || plantGroup.controls.nickname.hasError('minLength')">
+      Nickname is <strong>required</strong>
+    </mat-error>
+  </mat-form-field>
+  
+  <br />
+
+  <mat-form-field class="div-center">
+    <mat-label>Number of Plants</mat-label>
+    <input formControlName="count" matInput placeholder="Enter a number">
+     <mat-error *ngIf="plantGroup.controls.count.hasError('required') || plantGroup.controls.nickname.hasError('pattern') || plantGroup.controls.nickname.hasError('min')">
+      Number of plants is <strong>required</strong> and must be a positive number.
+    </mat-error>
+  </mat-form-field>
+</form>
+
+<table class="add-plant-form-table">
+  <tr>
+    <td><button mat-button class="button" (click)="close()">Cancel</button></td>
+    <td><button mat-button class="button" (click)="submit()">Add Plant</button></td>
+  </tr>
+</table>
+

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.spec.ts
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.spec.ts
@@ -1,0 +1,25 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {GrowpodUiModule} from '../common/growpod-ui.module';
+import {AddPlantComponent} from './add-plant-form.component';
+
+describe('AddPlantComponent', () => {
+  let component: AddPlantComponent;
+  let fixture: ComponentFixture<AddPlantComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [GrowpodUiModule],
+      declarations: [AddPlantComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddPlantComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.ts
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.ts
@@ -1,0 +1,75 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, OnInit} from '@angular/core';
+import {FormGroup, FormControl, Validators} from '@angular/forms';
+import {MatDialogRef} from '@angular/material/dialog';
+import {Plant} from '../model/plant.model';
+
+@Component({
+  selector: 'add-plant-form',
+  templateUrl: './add-plant-form.component.html',
+  styleUrls: [
+    './add-plant-form.component.css',
+    '../common/growpod-page-styles.css',
+  ],
+})
+
+/**
+ * Simple modal for adding a plant.
+ *
+ */
+export class AddPlantComponent implements OnInit {
+  plant: Plant = {
+    id: "1",
+    nickname: undefined,
+    count: undefined,
+    plantTypeId: "1",
+  };
+  plantGroup: FormGroup;
+
+  constructor(public dialogRef: MatDialogRef<AddPlantComponent, Plant>) {}
+
+  ngOnInit(): void {
+    this.plantGroup = new FormGroup({
+      nickname: new FormControl(this.plant.nickname, [
+        Validators.required,
+        Validators.minLength(1),
+      ]),
+      count: new FormControl(this.plant.count, [
+        Validators.required,
+        Validators.pattern("[0-9]+"),
+        Validators.min(1),
+      ])
+    });
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+
+  /**
+   * Closes the dialog with plant provided
+   * the input is valid.
+   *
+   */
+  submit(): void {
+    if (this.plantGroup.valid) {
+      this.plant = this.plantGroup.value;
+      this.plant.id = "1";
+      this.plant.plantTypeId = "1";
+      this.dialogRef.close(this.plant);
+    }
+  }
+}

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.ts
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.ts
@@ -32,10 +32,10 @@ import {Plant} from '../model/plant.model';
  */
 export class AddPlantComponent implements OnInit {
   plant: Plant = {
-    id: "1",
+    id: '1',
     nickname: undefined,
     count: undefined,
-    plantTypeId: "1",
+    plantTypeId: '1',
   };
   plantGroup: FormGroup;
 
@@ -49,9 +49,9 @@ export class AddPlantComponent implements OnInit {
       ]),
       count: new FormControl(this.plant.count, [
         Validators.required,
-        Validators.pattern("[0-9]+"),
+        Validators.pattern('[0-9]+'),
         Validators.min(1),
-      ])
+      ]),
     });
   }
 
@@ -67,8 +67,8 @@ export class AddPlantComponent implements OnInit {
   submit(): void {
     if (this.plantGroup.valid) {
       this.plant = this.plantGroup.value;
-      this.plant.id = "1";
-      this.plant.plantTypeId = "1";
+      this.plant.id = '1';
+      this.plant.plantTypeId = '1';
       this.dialogRef.close(this.plant);
     }
   }

--- a/src/main/webapp/src/app/admin-page/admin-page.component.css
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.css
@@ -1,0 +1,24 @@
+.card-padding {
+  padding: 20px;
+}
+
+.button-style {
+  display: block;
+  padding: 0.5em 3em;
+  text-decoration: none;
+  border: none;
+  box-sizing: border-box;
+  box-shadow: inset 0 -0.6em 0 -0.35em #003353;
+  background-color: #005c80;
+  color: white;
+}
+
+.button-style:hover {
+  box-shadow: inset 0 -0.6em 0 -0.35em whitesmoke;
+  background-color: white;
+  color: #005c80;
+}
+
+.growpod-spacer {
+  flex: 1 1 auto;
+}

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -3,9 +3,15 @@
     <mat-card class="growpod-main-section growpod-card">
       <div class="card-padding">
         <mat-card>
-          <h2>{{ gardenProfile.name }}</h2>
+          <button class="right-align" mat-button disabled>
+              <mat-icon color="warn">delete</mat-icon>
+            </button>
+          <h2>
+            {{ gardenProfile.name }}
+          </h2>
           <h4>
-            {{ gardenManager }} | {{ gardenProfile.lat + " -- " + gardenProfile.lng }}
+            {{ gardenManager }} |
+            {{ gardenProfile.lat + ' -- ' + gardenProfile.lng }}
           </h4>
         </mat-card>
       </div>
@@ -26,13 +32,16 @@
               </mat-expansion-panel-header>
               <mat-list role="list">
                 <div *ngIf="gardenPlantIdList">
-                  <mat-list-item role="list-item" *ngFor="let plantId of gardenPlantIdList">
+                  <mat-list-item
+                    role="list-item"
+                    *ngFor="let plantId of gardenPlantIdList"
+                  >
                     {{ gardenPlantNameMap && gardenPlantNameMap.get(plantId) }}
-                    <span class="mat-list-item-right-align">
+                    <span class="right-align">
                       <button mat-button>
                         <mat-icon color="accent">info</mat-icon>
                       </button>
-                      <button mat-button>
+                      <button mat-button (click)="removePlant(plantId)">
                         <mat-icon color="warn">delete</mat-icon>
                       </button>
                     </span>
@@ -46,15 +55,28 @@
                 <mat-panel-title> Members </mat-panel-title>
               </mat-expansion-panel-header>
               <mat-list role="list">
-                <mat-list-item role="list-item" *ngFor="let userId of gardenUserIdList">
+                <mat-list-item
+                  role="list-item"
+                  *ngFor="let userId of gardenUserIdList"
+                >
                   {{ gardenUserNameMap && gardenUserNameMap.get(userId) }}
-                  <span class="mat-list-item-right-align">
-                    <button mat-button [routerLink]="['/page/user-profile', {id: userId}]">
+                  <span class="right-align">
+                    <button
+                      mat-button
+                      [routerLink]="['/page/user-profile', {id: userId}]"
+                    >
                       <mat-icon color="accent">account_circle</mat-icon>
                     </button>
-                    <button mat-button>
-                      <mat-icon color="warn">delete</mat-icon>
-                    </button>
+                    <div *ngIf="userId !== gardenProfile.adminId; else disableDelete">
+                      <button mat-button (click)="removeUser(userId)">
+                        <mat-icon color="warn">delete</mat-icon>
+                      </button>
+                    </div>
+                    <ng-template #disableDelete>
+                      <button mat-button disabled>
+                        <mat-icon>verified_user</mat-icon>
+                      </button>
+                    </ng-template>
                   </span>
                 </mat-list-item>
               </mat-list>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -1,0 +1,77 @@
+<div *ngIf="isLoaded">
+  <div *ngIf="gardenProfile; else errorBlock">
+    <mat-card class="growpod-main-section growpod-card">
+      <div class="card-padding">
+        <mat-card>
+          <h2>{{ gardenProfile.name }}</h2>
+          <h4>
+            Caroline | {{ gardenProfile.lat + " -- " + gardenProfile.lng }}
+          </h4>
+          <button md-raised-button class="button-style">Go back</button>
+        </mat-card>
+      </div>
+
+      <div class="card-padding">
+        <mat-card>
+          <mat-accordion>
+            <mat-expansion-panel hideToggle>
+              <mat-expansion-panel-header>
+                <mat-panel-title> About the garden </mat-panel-title>
+              </mat-expansion-panel-header>
+              <p>Growing all the green things that look like peas.</p>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel hideToggle>
+              <mat-expansion-panel-header>
+                <mat-panel-title> Plants </mat-panel-title>
+              </mat-expansion-panel-header>
+              <mat-list>
+                <mat-list-item role="list-item">
+                  Plant
+                  <span class="mat-list-item-right-align">
+                    <button mat-button>
+                      <mat-icon color="accent">info</mat-icon>
+                    </button>
+                    <button mat-button>
+                      <mat-icon color="warn">delete</mat-icon>
+                    </button>
+                  </span>
+                </mat-list-item>
+              </mat-list>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel hideToggle>
+              <mat-expansion-panel-header>
+                <mat-panel-title> Members </mat-panel-title>
+              </mat-expansion-panel-header>
+              <mat-list role="list">
+                <mat-list-item role="list-item">
+                  Caroline
+                  <span class="mat-list-item-right-align">
+                    <button mat-button>
+                      <mat-icon color="accent">account_circle</mat-icon>
+                    </button>
+                    <button mat-button>
+                      <mat-icon color="warn">delete</mat-icon>
+                    </button>
+                  </span>
+                </mat-list-item>
+              </mat-list>
+            </mat-expansion-panel>
+          </mat-accordion>
+        </mat-card>
+      </div>
+    </mat-card>
+  </div>
+  <!-- Error case -->
+  <ng-template #errorBlock>
+    <mat-card class="growpod-main-section growpod-card">
+      <mat-card-content>
+        <h4 class="text-center">
+          <mat-icon aria-label="Error" color="warn">error</mat-icon>
+          {{ errorMessage }}
+        </h4>
+      </mat-card-content>
+    </mat-card>
+  </ng-template>
+</div>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -25,14 +25,14 @@
 
             <mat-expansion-panel hideToggle>
               <mat-expansion-panel-header>
-                  <mat-panel-title> 
-                    Plants
-                  </mat-panel-title>
-                  <mat-panel-description>
-                    <button class="right-align" mat-button (click)="addPlant()">
-                      <mat-icon color="accent">add_circle_outline</mat-icon>
-                    </button>
-                  </mat-panel-description>
+                <mat-panel-title>
+                  Plants
+                </mat-panel-title>
+                <mat-panel-description>
+                  <button class="right-align" mat-button (click)="addPlant()">
+                    <mat-icon color="accent">add_circle_outline</mat-icon>
+                  </button>
+                </mat-panel-description>
               </mat-expansion-panel-header>
               <mat-list role="list">
                 <div *ngIf="gardenPlantIdList">

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -5,9 +5,8 @@
         <mat-card>
           <h2>{{ gardenProfile.name }}</h2>
           <h4>
-            Caroline | {{ gardenProfile.lat + " -- " + gardenProfile.lng }}
+            {{ gardenManager }} | {{ gardenProfile.lat + " -- " + gardenProfile.lng }}
           </h4>
-          <button md-raised-button class="button-style">Go back</button>
         </mat-card>
       </div>
 
@@ -18,25 +17,27 @@
               <mat-expansion-panel-header>
                 <mat-panel-title> About the garden </mat-panel-title>
               </mat-expansion-panel-header>
-              <p>Growing all the green things that look like peas.</p>
+              <p>{{ gardenProfile.description }}</p>
             </mat-expansion-panel>
 
             <mat-expansion-panel hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title> Plants </mat-panel-title>
               </mat-expansion-panel-header>
-              <mat-list>
-                <mat-list-item role="list-item">
-                  Plant
-                  <span class="mat-list-item-right-align">
-                    <button mat-button>
-                      <mat-icon color="accent">info</mat-icon>
-                    </button>
-                    <button mat-button>
-                      <mat-icon color="warn">delete</mat-icon>
-                    </button>
-                  </span>
-                </mat-list-item>
+              <mat-list role="list">
+                <div *ngIf="gardenPlantIdList">
+                  <mat-list-item role="list-item" *ngFor="let plantId of gardenPlantIdList">
+                    {{ gardenPlantNameMap && gardenPlantNameMap.get(plantId) }}
+                    <span class="mat-list-item-right-align">
+                      <button mat-button>
+                        <mat-icon color="accent">info</mat-icon>
+                      </button>
+                      <button mat-button>
+                        <mat-icon color="warn">delete</mat-icon>
+                      </button>
+                    </span>
+                  </mat-list-item>
+                </div>
               </mat-list>
             </mat-expansion-panel>
 
@@ -45,10 +46,10 @@
                 <mat-panel-title> Members </mat-panel-title>
               </mat-expansion-panel-header>
               <mat-list role="list">
-                <mat-list-item role="list-item">
-                  Caroline
+                <mat-list-item role="list-item" *ngFor="let userId of gardenUserIdList">
+                  {{ gardenUserNameMap && gardenUserNameMap.get(userId) }}
                   <span class="mat-list-item-right-align">
-                    <button mat-button>
+                    <button mat-button [routerLink]="['/page/user-profile', {id: userId}]">
                       <mat-icon color="accent">account_circle</mat-icon>
                     </button>
                     <button mat-button>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -3,9 +3,6 @@
     <mat-card class="growpod-main-section growpod-card">
       <div class="card-padding">
         <mat-card>
-          <button class="right-align" mat-button disabled>
-            <mat-icon color="warn">delete</mat-icon>
-          </button>
           <h2>
             {{ gardenProfile.name }}
           </h2>
@@ -28,7 +25,14 @@
 
             <mat-expansion-panel hideToggle>
               <mat-expansion-panel-header>
-                <mat-panel-title> Plants </mat-panel-title>
+                  <mat-panel-title> 
+                    Plants
+                  </mat-panel-title>
+                  <mat-panel-description>
+                    <button class="right-align" mat-button (click)="addPlant()">
+                      <mat-icon color="accent">add_circle_outline</mat-icon>
+                    </button>
+                  </mat-panel-description>
               </mat-expansion-panel-header>
               <mat-list role="list">
                 <div *ngIf="gardenPlantIdList">

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -4,8 +4,8 @@
       <div class="card-padding">
         <mat-card>
           <button class="right-align" mat-button disabled>
-              <mat-icon color="warn">delete</mat-icon>
-            </button>
+            <mat-icon color="warn">delete</mat-icon>
+          </button>
           <h2>
             {{ gardenProfile.name }}
           </h2>
@@ -67,7 +67,12 @@
                     >
                       <mat-icon color="accent">account_circle</mat-icon>
                     </button>
-                    <div *ngIf="userId !== gardenProfile.adminId; else disableDelete">
+                    <div
+                      *ngIf="
+                        userId !== gardenProfile.adminId;
+                        else disableDelete
+                      "
+                    >
                       <button mat-button (click)="removeUser(userId)">
                         <mat-icon color="warn">delete</mat-icon>
                       </button>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -71,7 +71,7 @@
                     >
                       <mat-icon color="accent">account_circle</mat-icon>
                     </button>
-                    <div
+                    <span
                       *ngIf="
                         userId !== gardenProfile.adminId;
                         else disableDelete
@@ -80,7 +80,7 @@
                       <button mat-button (click)="removeUser(userId)">
                         <mat-icon color="warn">delete</mat-icon>
                       </button>
-                    </div>
+                    </span>
                     <ng-template #disableDelete>
                       <button mat-button disabled>
                         <mat-icon>verified_user</mat-icon>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.spec.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.spec.ts
@@ -1,0 +1,26 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {GrowpodUiModule} from '../common/growpod-ui.module';
+import {AdminPageComponent} from './admin-page.component';
+import {DatepickerComponent} from '../datepicker/datepicker.component';
+
+describe('AdminPageComponent', () => {
+  let component: AdminPageComponent;
+  let fixture: ComponentFixture<AdminPageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [GrowpodUiModule],
+      declarations: [AdminPageComponent, DatepickerComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -73,6 +73,7 @@ export class AdminPageComponent implements OnInit {
     if (!gardenIdArg) {
       this.gardenProfile = null;
       this.errorMessage = 'No garden-id argument in the query string.';
+      this.isLoaded = true;
       return;
     }
     this.createAdminPage(gardenIdArg);
@@ -164,30 +165,36 @@ export class AdminPageComponent implements OnInit {
    * Deletes a plant from a garden.
    *
    * Performs GET: /garden/{{gardenProfile.id}}/plant-list/{id}
-   * 
+   *
    * @param id the plant id to delete.
    * @return the http response.
    */
   deleteFromGardenPlantList(id: string): Observable<HttpResponse<string>> {
-    return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/plant-list/' + id, {
-      observe: 'response',
-      responseType: 'json',
-    });
+    return this.httpClient.delete<string>(
+      '/garden/' + this.gardenProfile.id + '/plant-list/' + id,
+      {
+        observe: 'response',
+        responseType: 'json',
+      }
+    );
   }
 
   /**
    * Deletes a user from a garden.
    *
    * Performs GET: /garden/{{gardenProfile.id}}/user-list/{id}
-   * 
+   *
    * @param id the user id to delete.
    * @return the http response.
    */
   deleteFromGardenUserList(id: string): Observable<HttpResponse<string>> {
-    return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/user-list/' + id, {
-      observe: 'response',
-      responseType: 'json',
-    });
+    return this.httpClient.delete<string>(
+      '/garden/' + this.gardenProfile.id + '/user-list/' + id,
+      {
+        observe: 'response',
+        responseType: 'json',
+      }
+    );
   }
 
   /**
@@ -391,7 +398,7 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Unexpected error: ' + error.statusText);
       },
-    })
+    });
   }
 
   /**
@@ -412,6 +419,6 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Unexpected error: ' + error.statusText);
       },
-    })
+    });
   }
 }

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -66,7 +66,11 @@ export class AdminPageComponent implements OnInit {
    *
    * @param route Contains arguments.
    */
-  constructor(private route: ActivatedRoute, private httpClient: HttpClient, private dialog: MatDialog) {}
+  constructor(
+    private route: ActivatedRoute,
+    private httpClient: HttpClient,
+    private dialog: MatDialog
+  ) {}
 
   ngOnInit(): void {
     const gardenIdArg = this.route.snapshot.paramMap.get('garden-id');

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -54,7 +54,11 @@ export class AdminPageComponent implements OnInit {
   // Plant list
   gardenPlantIdList: Array<string> | null = null;
   gardenPlantNameMap: Map<string, string>;
-  gardenPlantIdListError = ''
+  gardenPlantIdListError = '';
+
+  // General Error Handling
+  showModal = false;
+  modalMessage = '';
   errorMessage = '';
 
   /**

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -1,0 +1,219 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {
+  HttpClient,
+  HttpResponse,
+  HttpErrorResponse,
+} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import {Garden} from '../model/garden.model';
+import {Plant} from '../model/plant.model';
+import {User} from '../model/user.model';
+
+@Component({
+  selector: 'admin-page',
+  templateUrl: './admin-page.component.html',
+  styleUrls: [
+    './admin-page.component.css',
+    '../common/growpod-page-styles.css',
+  ],
+})
+
+/**
+ * This is a component designed to allow administrators to manage the gardens they
+ * own.
+ *
+ * This page takes an argument 'garden-id'. This is not optional, and determines
+ * the garden that is being administered. Only the garden owner can make changes to
+ * their garden.
+ */
+export class AdminPageComponent implements OnInit {
+  isLoaded = true;
+  gardenProfile: Garden | null;
+  gardenUserIdList: Array<string> | null = null;
+  gardenUserList: Array<User>;
+  gardenPlantIdList: Array<string> | null = null;
+  gardenPlantList: Array<Plant>;
+  errorMessage = '';
+
+  /**
+   * Initializes the component based on provided arguments
+   *
+   * @param route Contains arguments.
+   */
+  constructor(private route: ActivatedRoute, private httpClient: HttpClient) {}
+
+  ngOnInit(): void {
+    const gardenIdArg = this.route.snapshot.paramMap.get('garden-id');
+    if (!gardenIdArg) {
+      this.gardenProfile = null;
+      this.errorMessage = 'No garden-id argument in the query string.';
+      return;
+    }
+    this.createAdminPage(gardenIdArg);
+  }
+
+  /**
+   * Gets garden information for the specified garden from
+   * the server. Returns an observable HTTP response.
+   *
+   * Performs GET: /garden/{garden}
+   *
+   * @param garden The garden reqested from the server.
+   * @return the http response.
+   */
+  getGardenInfo(garden: string): Observable<HttpResponse<Garden>> {
+    return this.httpClient.get<Garden>('/garden/' + garden, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
+   * Gets all users this garden contains.
+   *
+   * Performs GET: /garden/{garden}/user-list
+   *
+   * @return the http response.
+   */
+  getCurrentGardenUserList(
+    garden: string
+  ): Observable<HttpResponse<Array<String>>> {
+    return this.httpClient.get<Array<String>>(
+      '/garden/' + garden + '/user-list',
+      {
+        observe: 'response',
+        responseType: 'json',
+      }
+    );
+  }
+
+  /**
+   * Gets all plants this garden contains.
+   *
+   * Performs GET: /garden/{garden}/plant-list
+   *
+   * @return the http response.
+   */
+  getCurrentGardenPlantList(
+    garden: string
+  ): Observable<HttpResponse<Array<String>>> {
+    return this.httpClient.get<Array<String>>(
+      '/garden/' + garden + '/plant-list',
+      {
+        observe: 'response',
+        responseType: 'json',
+      }
+    );
+  }
+
+  /**
+   * Gets user information for the specified user from
+   * the server. Returns an observable HTTP response.
+   *
+   * Performs GET: /user/{user}
+   *
+   * @param user The user reqested from the server.
+   * @return the http response.
+   */
+  getUserInfo(user: string): Observable<HttpResponse<User>> {
+    return this.httpClient.get<User>('/user/' + user, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
+   * Gets plant information for the specified plant from
+   * the server. Returns an observable HTTP response.
+   *
+   * Performs GET: /plant/{plant}
+   *
+   * @param plant The plant reqested from the server.
+   * @return the http response.
+   */
+  getPlantInfo(plant: string): Observable<HttpResponse<Plant>> {
+    return this.httpClient.get<Plant>('/plant/' + plant, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
+   * Creates garden summary.
+   *
+   * @param garden The garden to create an admin page of.
+   */
+  createGardenSummary(garden: string): void {
+    this.getGardenInfo(garden).subscribe({
+      next: (response: HttpResponse<Garden>) => {
+        // Successful responses are handled here.
+        this.gardenProfile = response.body;
+        this.isLoaded = true;
+        // Get rest of information
+        this.createGardenUserList(garden);
+        this.createGardenPlantList(garden);
+      },
+      error: (error: HttpErrorResponse) => {
+        // Handle connection error
+        if (error.error instanceof ErrorEvent) {
+          console.error('Network error: ' + error.error.message);
+          this.gardenProfile = null;
+          this.errorMessage = 'Cannot connect to GrowPod Server';
+          this.isLoaded = true;
+          return;
+        }
+        // Non-404 error codes
+        if (error.status !== 404) {
+          console.error('Unexpected error: ' + error.statusText);
+          this.gardenProfile = null;
+          this.errorMessage =
+            'Unexpected error ' + error.status + ': ' + error.statusText;
+          this.isLoaded = true;
+          return;
+        }
+        console.error('Error ' + error.status + ': ' + error.statusText);
+        this.gardenProfile = null;
+        this.errorMessage = 'Cannot see garden profile for user id: ' + garden;
+        this.isLoaded = true;
+      },
+    });
+  }
+
+  /**
+   * Creates garden user list.
+   *
+   * @param garden The garden to create a user list of.
+   */
+  createGardenUserList(garden: string): void {}
+
+  /**
+   * Creates garden plant list.
+   *
+   * @param garden The garden to create a plant list of.
+   */
+  createGardenPlantList(garden: string): void {}
+
+  /**
+   * Creates garden administration page based on the given garden id.
+   *
+   * @param garden The garden to create an admin page of.
+   */
+  createAdminPage(garden: string): void {
+    this.createGardenSummary(garden);
+  }
+}

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -56,7 +56,7 @@ export class AdminPageComponent implements OnInit {
   // Plant list
   gardenPlantIdList: Array<string> | null = null;
   gardenPlantNameMap: Map<string, string>;
-  gardenPlantIdListError = '';
+  gardenPlantIdListError = 'Plant list not loaded';
 
   // General Error Handling
   errorMessage = '';

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -101,9 +101,7 @@ export class AdminPageComponent implements OnInit {
    *
    * @return the http response.
    */
-  getGardenUserList(
-    garden: string
-  ): Observable<HttpResponse<Array<String>>> {
+  getGardenUserList(garden: string): Observable<HttpResponse<Array<String>>> {
     return this.httpClient.get<Array<String>>(
       '/garden/' + garden + '/user-list',
       {
@@ -120,9 +118,7 @@ export class AdminPageComponent implements OnInit {
    *
    * @return the http response.
    */
-  getGardenPlantList(
-    garden: string
-  ): Observable<HttpResponse<Array<String>>> {
+  getGardenPlantList(garden: string): Observable<HttpResponse<Array<String>>> {
     return this.httpClient.get<Array<String>>(
       '/garden/' + garden + '/plant-list',
       {
@@ -165,6 +161,36 @@ export class AdminPageComponent implements OnInit {
   }
 
   /**
+   * Deletes a plant from a garden.
+   *
+   * Performs GET: /garden/{{gardenProfile.id}}/plant-list/{id}
+   * 
+   * @param id the plant id to delete.
+   * @return the http response.
+   */
+  deleteFromGardenPlantList(id: string): Observable<HttpResponse<string>> {
+    return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/plant-list/' + id, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
+   * Deletes a user from a garden.
+   *
+   * Performs GET: /garden/{{gardenProfile.id}}/user-list/{id}
+   * 
+   * @param id the user id to delete.
+   * @return the http response.
+   */
+  deleteFromGardenUserList(id: string): Observable<HttpResponse<string>> {
+    return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/user-list/' + id, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
    * Creates garden summary.
    *
    * @param garden The garden to create an admin page of.
@@ -178,7 +204,7 @@ export class AdminPageComponent implements OnInit {
         // Get rest of information
         this.createGardenUserList(garden);
         this.createGardenPlantList(garden);
-        this.gardenManager = "Loading";
+        this.gardenManager = 'Loading';
         this.getUserInfo(this.gardenProfile.adminId).subscribe({
           next: (response: HttpResponse<User>) => {
             this.gardenManager = response.body.preferredName;
@@ -215,7 +241,8 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Error ' + error.status + ': ' + error.statusText);
         this.gardenProfile = null;
-        this.errorMessage = 'Cannot see garden profile for garden id: ' + garden;
+        this.errorMessage =
+          'Cannot see garden profile for garden id: ' + garden;
         this.isLoaded = true;
       },
     });
@@ -234,15 +261,12 @@ export class AdminPageComponent implements OnInit {
         // Gets user names
         this.gardenUserNameMap = new Map<string, string>();
         this.gardenUserIdList.forEach(id => {
-          this.gardenUserNameMap.set(id, "Loading...");
+          this.gardenUserNameMap.set(id, 'Loading...');
           this.getUserInfo(id).subscribe({
             // Obtain user names
             next: (response: HttpResponse<User>) => {
               // Successful responses are handled here.
-              this.gardenUserNameMap.set(
-                id,
-                response.body.preferredName
-              );
+              this.gardenUserNameMap.set(id, response.body.preferredName);
             },
             error: (error: HttpErrorResponse) => {
               // Handle connection error
@@ -275,7 +299,8 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Error ' + error.status + ': ' + error.statusText);
         this.gardenUserIdList = null;
-        this.gardenUserIdListError = 'Cannot see user list for garden id: ' + garden;
+        this.gardenUserIdListError =
+          'Cannot see user list for garden id: ' + garden;
         this.isLoaded = true;
       },
     });
@@ -294,15 +319,12 @@ export class AdminPageComponent implements OnInit {
         // Get plant names
         this.gardenPlantNameMap = new Map<string, string>();
         this.gardenPlantIdList.forEach(id => {
-          this.gardenPlantNameMap.set(id, "Loading...");
+          this.gardenPlantNameMap.set(id, 'Loading...');
           this.getPlantInfo(id).subscribe({
             // Obtain plant names
             next: (response: HttpResponse<Plant>) => {
               // Successful responses are handled here.
-              this.gardenPlantNameMap.set(
-                id,
-                response.body.nickname
-              );
+              this.gardenPlantNameMap.set(id, response.body.nickname);
             },
             error: (error: HttpErrorResponse) => {
               // Handle connection error
@@ -335,7 +357,8 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Error ' + error.status + ': ' + error.statusText);
         this.gardenPlantIdList = null;
-        this.gardenPlantIdListError = 'Cannot see plant list for garden id: ' + garden;
+        this.gardenPlantIdListError =
+          'Cannot see plant list for garden id: ' + garden;
         this.isLoaded = true;
       },
     });
@@ -348,5 +371,47 @@ export class AdminPageComponent implements OnInit {
    */
   createAdminPage(garden: string): void {
     this.createGardenSummary(garden);
+  }
+
+  /**
+   * Removes a plant from a garden.
+   *
+   * @param id The plant id to delete.
+   */
+  removePlant(id: string): void {
+    this.deleteFromGardenPlantList(id).subscribe({
+      next: () => {
+        this.createGardenPlantList(this.gardenProfile.id);
+      },
+      error: (error: HttpErrorResponse) => {
+        // Do nothing visible for errors, yet
+        if (error.error instanceof ErrorEvent) {
+          console.error('Network error: ' + error.error.message);
+          return;
+        }
+        console.error('Unexpected error: ' + error.statusText);
+      },
+    })
+  }
+
+  /**
+   * Removes a user from a garden.
+   *
+   * @param id The user id to delete.
+   */
+  removeUser(id: string): void {
+    this.deleteFromGardenUserList(id).subscribe({
+      next: () => {
+        this.createGardenUserList(this.gardenProfile.id);
+      },
+      error: (error: HttpErrorResponse) => {
+        // Do nothing visible for errors, yet
+        if (error.error instanceof ErrorEvent) {
+          console.error('Network error: ' + error.error.message);
+          return;
+        }
+        console.error('Unexpected error: ' + error.statusText);
+      },
+    })
   }
 }

--- a/src/main/webapp/src/app/app-routing.module.ts
+++ b/src/main/webapp/src/app/app-routing.module.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLCn
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/main/webapp/src/app/app-routing.module.ts
+++ b/src/main/webapp/src/app/app-routing.module.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020 Google LLCn
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import {UserProfileComponent} from './user-profile/user-profile.component';
 import {FindGardensComponent} from './find-gardens-page/find-gardens.component';
 import {SchedulePageComponent} from './schedule-page/schedule-page.component';
 import {CreateGardensComponent} from './create-gardens-form/create-gardens.component';
+import {AdminPageComponent} from './admin-page/admin-page.component';
 
 /**
  * The routing table for all frontend pages
@@ -34,6 +35,7 @@ const routes: Routes = [
   {path: 'page/find-gardens', component: FindGardensComponent},
   {path: 'page/schedule', component: SchedulePageComponent},
   {path: 'page/create-garden', component: CreateGardensComponent},
+  {path: 'page/admin-page', component: AdminPageComponent},
   /** Defaults to /my-gardens */
   {path: '', redirectTo: '/page/my-gardens', pathMatch: 'full'},
 ];

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -29,6 +29,7 @@ import {SchedulePageComponent} from './schedule-page/schedule-page.component';
 import {CreateGardensComponent} from './create-gardens-form/create-gardens.component';
 import {DatepickerComponent} from './datepicker/datepicker.component';
 import {AdminPageComponent} from './admin-page/admin-page.component';
+import {AddPlantComponent} from './add-plant-form/add-plant-form.component';
 
 @NgModule({
   declarations: [
@@ -40,6 +41,7 @@ import {AdminPageComponent} from './admin-page/admin-page.component';
     CreateGardensComponent,
     DatepickerComponent,
     AdminPageComponent,
+    AddPlantComponent,
   ],
   imports: [
     BrowserModule,
@@ -47,6 +49,9 @@ import {AdminPageComponent} from './admin-page/admin-page.component';
     AppRoutingModule,
     RouterModule,
     GrowpodUiModule,
+  ],
+  entryComponents: [
+    AddPlantComponent,
   ],
 
   bootstrap: [AppComponent],

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -50,9 +50,7 @@ import {AddPlantComponent} from './add-plant-form/add-plant-form.component';
     RouterModule,
     GrowpodUiModule,
   ],
-  entryComponents: [
-    AddPlantComponent,
-  ],
+  entryComponents: [AddPlantComponent],
 
   bootstrap: [AppComponent],
 })

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -28,6 +28,7 @@ import {FindGardensComponent} from './find-gardens-page/find-gardens.component';
 import {SchedulePageComponent} from './schedule-page/schedule-page.component';
 import {CreateGardensComponent} from './create-gardens-form/create-gardens.component';
 import {DatepickerComponent} from './datepicker/datepicker.component';
+import {AdminPageComponent} from './admin-page/admin-page.component';
 
 @NgModule({
   declarations: [
@@ -38,6 +39,7 @@ import {DatepickerComponent} from './datepicker/datepicker.component';
     SchedulePageComponent,
     CreateGardensComponent,
     DatepickerComponent,
+    AdminPageComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/main/webapp/src/app/common/growpod-page-styles.css
+++ b/src/main/webapp/src/app/common/growpod-page-styles.css
@@ -100,3 +100,7 @@
   object-position: center;
   border-radius: 50%;
 }
+
+.mat-list-item-right-align {
+  margin-left: auto;
+}

--- a/src/main/webapp/src/app/common/growpod-page-styles.css
+++ b/src/main/webapp/src/app/common/growpod-page-styles.css
@@ -104,3 +104,7 @@
 .right-align {
   margin-left: auto;
 }
+
+.div-center {
+  margin: 0 auto;
+}

--- a/src/main/webapp/src/app/common/growpod-page-styles.css
+++ b/src/main/webapp/src/app/common/growpod-page-styles.css
@@ -101,6 +101,6 @@
   border-radius: 50%;
 }
 
-.mat-list-item-right-align {
+.right-align {
   margin-left: auto;
 }

--- a/src/main/webapp/src/app/common/material.module.ts
+++ b/src/main/webapp/src/app/common/material.module.ts
@@ -25,6 +25,7 @@ import {MatDatepickerModule} from '@angular/material/datepicker';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
 import {MatSelectModule} from '@angular/material/select';
+import {MatListModule} from '@angular/material/list';
 
 @NgModule({
   exports: [
@@ -39,6 +40,7 @@ import {MatSelectModule} from '@angular/material/select';
     MatDatepickerModule,
     MatFormFieldModule,
     MatSelectModule,
+    MatListModule,
   ],
   providers: [
     {provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {appearance: 'fill'}},

--- a/src/main/webapp/src/app/common/material.module.ts
+++ b/src/main/webapp/src/app/common/material.module.ts
@@ -26,6 +26,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
 import {MatSelectModule} from '@angular/material/select';
 import {MatListModule} from '@angular/material/list';
+import {MatDialogModule} from '@angular/material/dialog';
 
 @NgModule({
   exports: [
@@ -41,6 +42,7 @@ import {MatListModule} from '@angular/material/list';
     MatFormFieldModule,
     MatSelectModule,
     MatListModule,
+    MatDialogModule,
   ],
   providers: [
     {provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {appearance: 'fill'}},

--- a/src/main/webapp/src/app/model/plant.model.ts
+++ b/src/main/webapp/src/app/model/plant.model.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Plant interface that corresponds with design doc specs.
+ *
+ */
+export interface Plant {
+  id: string;
+  nickname: string;
+  count: number;
+  plantTypeId: string;
+}

--- a/src/test/java/com/google/growpod/servlets/GardenServletTest.java
+++ b/src/test/java/com/google/growpod/servlets/GardenServletTest.java
@@ -43,6 +43,7 @@ public final class GardenServletTest {
 
   /** Test values. */
   private final Garden TEST_GARDEN = new Garden("0", "x", "y", 0.0, 0.0, "0", "0");
+
   private final Plant TEST_PLANT = new Plant("0", "x", 1, "y");
   /** Separate lists in case I change the type each query returns */
   private final List<String> TEST_USER_LIST = Arrays.asList("0");

--- a/src/test/java/com/google/growpod/servlets/GardenServletTest.java
+++ b/src/test/java/com/google/growpod/servlets/GardenServletTest.java
@@ -166,4 +166,56 @@ public final class GardenServletTest {
 
     assertEquals(MockHttpServletResponse.SC_METHOD_NOT_ALLOWED, response.getStatus());
   }
+
+  /** Tests successful query for DELETE: /garden/{gid}/user-list/{uid}. */
+  @Test
+  public void doDelete_successfulUserListQuery_successfulResult() throws IOException {
+    String testUrl = "/garden/0/user-list/0";
+
+    // Mocks
+    MockHttpServletRequest request = new MockHttpServletRequest("DELETE", testUrl);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(dao.deleteFromGardenUserList("0", "0")).thenReturn(true);
+
+    servlet.doDelete(request, response);
+
+    assertEquals("application/json;", response.getContentType());
+    assertEquals("{\"id\":0}", response.getContentAsString().trim());
+  }
+
+  // TODO test failed query when behavior becomes defined
+
+  /** Tests successful query for DELETE: /garden/{gid}/user-list/{uid}. */
+  @Test
+  public void doDelete_successfulPlantListQuery_successfulResult() throws IOException {
+    String testUrl = "/garden/0/plant-list/0";
+
+    // Mocks
+    MockHttpServletRequest request = new MockHttpServletRequest("DELETE", testUrl);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(dao.deleteFromGardenPlantList("0", "0")).thenReturn(true);
+
+    servlet.doDelete(request, response);
+
+    assertEquals("application/json;", response.getContentType());
+    assertEquals("{\"id\":0}", response.getContentAsString().trim());
+  }
+
+  // TODO test failed query when behavior becomes defined
+
+  /** Tests invalid method on DELETE. */
+  @Test
+  public void doDelete_invalidUrlQuery_returns405() throws IOException {
+    String testUrl = "/garden/peapod/cody-kayla-stephanie-caroline-jake";
+
+    // Mocks
+    MockHttpServletRequest request = new MockHttpServletRequest("DELETE", testUrl);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    servlet.doGet(request, response);
+
+    assertEquals(MockHttpServletResponse.SC_METHOD_NOT_ALLOWED, response.getStatus());
+  }
 }

--- a/src/test/java/com/google/growpod/servlets/GardenServletTest.java
+++ b/src/test/java/com/google/growpod/servlets/GardenServletTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.growpod.controllers.GardenDao;
 import com.google.growpod.data.Garden;
+import com.google.growpod.data.Plant;
 import com.google.growpod.servlets.GardenServlet;
 import com.google.gson.Gson;
 import java.io.IOException;
@@ -42,6 +43,7 @@ public final class GardenServletTest {
 
   /** Test values. */
   private final Garden TEST_GARDEN = new Garden("0", "x", "y", 0.0, 0.0, "0", "0");
+  private final Plant TEST_PLANT = new Plant("0", "x", 1, "y");
   /** Separate lists in case I change the type each query returns */
   private final List<String> TEST_USER_LIST = Arrays.asList("0");
 
@@ -167,6 +169,40 @@ public final class GardenServletTest {
     assertEquals(MockHttpServletResponse.SC_METHOD_NOT_ALLOWED, response.getStatus());
   }
 
+  /** Tests successful query for POST: /garden/{gid}/plant-list posting */
+  @Test
+  public void doPost_successfulPlantListQuery_successfulResult() throws IOException {
+    String testUrl = "/garden/0/plant-list";
+
+    // Mocks
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", testUrl);
+    request.setContent(new Gson().toJson(TEST_PLANT).getBytes());
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(dao.addToGardenPlantList("0", TEST_PLANT)).thenReturn("0");
+
+    servlet.doPost(request, response);
+
+    assertEquals("application/json;", response.getContentType());
+    assertEquals("{\"id\":0}", response.getContentAsString().trim());
+  }
+
+  // TODO test failed query when behavior becomes defined
+
+  /** Tests invalid method on POST. */
+  @Test
+  public void doPost_invalidUrlQuery_returns405() throws IOException {
+    String testUrl = "/garden/peapod/cody-kayla-stephanie-caroline-jake";
+
+    // Mocks
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", testUrl);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    servlet.doGet(request, response);
+
+    assertEquals(MockHttpServletResponse.SC_METHOD_NOT_ALLOWED, response.getStatus());
+  }
+
   /** Tests successful query for DELETE: /garden/{gid}/user-list/{uid}. */
   @Test
   public void doDelete_successfulUserListQuery_successfulResult() throws IOException {
@@ -186,7 +222,7 @@ public final class GardenServletTest {
 
   // TODO test failed query when behavior becomes defined
 
-  /** Tests successful query for DELETE: /garden/{gid}/user-list/{uid}. */
+  /** Tests successful query for DELETE: /garden/{gid}/plant-list/{uid}. */
   @Test
   public void doDelete_successfulPlantListQuery_successfulResult() throws IOException {
     String testUrl = "/garden/0/plant-list/0";

--- a/src/test/java/com/google/growpod/servlets/GardenServletTest.java
+++ b/src/test/java/com/google/growpod/servlets/GardenServletTest.java
@@ -170,6 +170,41 @@ public final class GardenServletTest {
     assertEquals(MockHttpServletResponse.SC_METHOD_NOT_ALLOWED, response.getStatus());
   }
 
+  /** Tests invalid garden id response for POST: /garden/{gid}/plant-list */
+  @Test
+  public void doPost_invalidGidPlantListQuery_returns404() throws IOException {
+    String testUrl = "/garden/0/plant-list";
+
+    // Mocks
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", testUrl);
+    request.setContent(new Gson().toJson(TEST_PLANT).getBytes());
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(dao.getGardenById("0")).thenReturn(null);
+
+    servlet.doPost(request, response);
+
+    assertEquals(MockHttpServletResponse.SC_NOT_FOUND, response.getStatus());
+  }
+
+  /** Tests invalid request body response for POST: /garden/{gid}/plant-list */
+  @Test
+  public void doPost_invalidRequestBodyPlantListQuery_returns400() throws IOException {
+    String testUrl = "/garden/0/plant-list";
+
+    // Mocks
+    MockHttpServletRequest request = new MockHttpServletRequest("POST", testUrl);
+    request.setContent(new Gson().toJson(TEST_PLANT).getBytes());
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(dao.addToGardenPlantList("0", TEST_PLANT)).thenReturn(null);
+    when(dao.getGardenById("0")).thenReturn(TEST_GARDEN);
+
+    servlet.doPost(request, response);
+
+    assertEquals(MockHttpServletResponse.SC_BAD_REQUEST, response.getStatus());
+  }
+
   /** Tests successful query for POST: /garden/{gid}/plant-list posting */
   @Test
   public void doPost_successfulPlantListQuery_successfulResult() throws IOException {
@@ -181,14 +216,13 @@ public final class GardenServletTest {
     MockHttpServletResponse response = new MockHttpServletResponse();
 
     when(dao.addToGardenPlantList("0", TEST_PLANT)).thenReturn("0");
+    when(dao.getGardenById("0")).thenReturn(TEST_GARDEN);
 
     servlet.doPost(request, response);
 
     assertEquals("application/json;", response.getContentType());
     assertEquals("{\"id\":0}", response.getContentAsString().trim());
   }
-
-  // TODO test failed query when behavior becomes defined
 
   /** Tests invalid method on POST. */
   @Test
@@ -221,9 +255,23 @@ public final class GardenServletTest {
     assertEquals("{\"id\":0}", response.getContentAsString().trim());
   }
 
-  // TODO test failed query when behavior becomes defined
+  /** Tests failed query for DELETE: /garden/{gid}/user-list/{uid} */
+  @Test
+  public void doPost_invalidGidOrPidUserListQuery_returns404() throws IOException {
+    String testUrl = "/garden/0/user-list/0";
 
-  /** Tests successful query for DELETE: /garden/{gid}/plant-list/{uid}. */
+    // Mocks
+    MockHttpServletRequest request = new MockHttpServletRequest("DELETE", testUrl);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(dao.deleteFromGardenUserList("0", "0")).thenReturn(false);
+
+    servlet.doDelete(request, response);
+
+    assertEquals(MockHttpServletResponse.SC_NOT_FOUND, response.getStatus());
+  }
+
+  /** Tests successful query for DELETE: /garden/{gid}/plant-list/{pid}. */
   @Test
   public void doDelete_successfulPlantListQuery_successfulResult() throws IOException {
     String testUrl = "/garden/0/plant-list/0";
@@ -240,7 +288,21 @@ public final class GardenServletTest {
     assertEquals("{\"id\":0}", response.getContentAsString().trim());
   }
 
-  // TODO test failed query when behavior becomes defined
+  /** Tests failed query for DELETE: /garden/{gid}/plant-list/{pid} */
+  @Test
+  public void doPost_invalidGidOrPidPlantListQuery_returns404() throws IOException {
+    String testUrl = "/garden/0/plant-list/0";
+
+    // Mocks
+    MockHttpServletRequest request = new MockHttpServletRequest("DELETE", testUrl);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    when(dao.deleteFromGardenPlantList("0", "0")).thenReturn(false);
+
+    servlet.doDelete(request, response);
+
+    assertEquals(MockHttpServletResponse.SC_NOT_FOUND, response.getStatus());
+  }
 
   /** Tests invalid method on DELETE. */
   @Test


### PR DESCRIPTION
**Major Changes:**
1. Add administer page, accessible at `/page/admin-page;garden-id={garden-id}`. Note the way for passing client-side arguments in Angular, as well as that `garden-id` is required.
2. Allow admins to add plants to their gardens. Input is validated using Angular `FormControl` validation. No authentication is done since login hasn't been merged yet.
3. Allow admins to remove users and plants.
4. Write API calls for `DELETE:/garden/{gid}/{user-list | plant-list}/{id}`, and `POST:/garden/{gid}/plant-list`.
5. Write tests for these API calls.

**TODO:**
1. Fix styling.

**For later:**
1. Add frontend unit testing.
2. Allow editing of plant nickname
3. STRETCH: Add geocoding.

![image](https://user-images.githubusercontent.com/42156440/88857965-d8d33a80-d1bc-11ea-9d47-a7668a3a19c1.png)
![image](https://user-images.githubusercontent.com/42156440/88858045-ff917100-d1bc-11ea-8973-7f9e49c5a854.png)
![image](https://user-images.githubusercontent.com/42156440/88858292-631b9e80-d1bd-11ea-8975-8a7ffd82b1e2.png)
![image](https://user-images.githubusercontent.com/42156440/88858348-7a5a8c00-d1bd-11ea-8282-5d7bd002b713.png)


