### PR TITLE
Plant Detail Modal

### DIFF
--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -42,7 +42,7 @@
                   >
                     {{ gardenPlantNameMap && gardenPlantNameMap.get(plantId) }}
                     <span class="right-align">
-                      <button mat-button>
+                      <button mat-button (click)="showPlantDetails(plantId)">
                         <mat-icon color="accent">info</mat-icon>
                       </button>
                       <button mat-button (click)="removePlant(plantId)">

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -22,6 +22,7 @@ import {
 import {Observable} from 'rxjs';
 import {MatDialog} from '@angular/material/dialog';
 import {AddPlantComponent} from '../add-plant-form/add-plant-form.component';
+import {PlantModalComponent} from '../plant-modal/plant-modal.component';
 import {Garden} from '../model/garden.model';
 import {Plant} from '../model/plant.model';
 import {User} from '../model/user.model';
@@ -403,6 +404,31 @@ export class AdminPageComponent implements OnInit {
    */
   createAdminPage(garden: string): void {
     this.createGardenSummary(garden);
+  }
+
+  /**
+   * Opens a modal containing more information about a particular plant.
+   *
+   * @param id the plant id to show more information about.
+   */
+  showPlantDetails(id: string) {
+    this.getPlantInfo(id).subscribe({
+      // Obtain plant names
+      next: (response: HttpResponse<Plant>) => {
+        // Successful responses are handled here.
+        this.dialog.open(PlantModalComponent, {
+          data: response.body,
+        });
+      },
+      error: (error: HttpErrorResponse) => {
+        // Do nothing visible for errors yet
+        if (error.error instanceof ErrorEvent) {
+          console.error('Network error: ' + error.error.message);
+          return;
+        }
+        console.error('Unexpected error: ' + error.statusText);
+      },
+    });
   }
 
   /**

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -30,6 +30,7 @@ import {CreateGardensComponent} from './create-gardens-form/create-gardens.compo
 import {DatepickerComponent} from './datepicker/datepicker.component';
 import {AdminPageComponent} from './admin-page/admin-page.component';
 import {AddPlantComponent} from './add-plant-form/add-plant-form.component';
+import {PlantModalComponent} from './plant-modal/plant-modal.component';
 
 @NgModule({
   declarations: [
@@ -42,6 +43,7 @@ import {AddPlantComponent} from './add-plant-form/add-plant-form.component';
     DatepickerComponent,
     AdminPageComponent,
     AddPlantComponent,
+    PlantModalComponent,
   ],
   imports: [
     BrowserModule,
@@ -50,7 +52,7 @@ import {AddPlantComponent} from './add-plant-form/add-plant-form.component';
     RouterModule,
     GrowpodUiModule,
   ],
-  entryComponents: [AddPlantComponent],
+  entryComponents: [AddPlantComponent, PlantModalComponent],
 
   bootstrap: [AppComponent],
 })

--- a/src/main/webapp/src/app/plant-modal/plant-modal.component.html
+++ b/src/main/webapp/src/app/plant-modal/plant-modal.component.html
@@ -1,0 +1,27 @@
+<h2 mat-dialog-title>
+  Plant Detail
+</h2>
+
+<table class="div-center">
+  <tr>
+    <td>
+      <strong>Plant Nickname: </strong>
+    </td>
+    <td>
+      {{ plant.nickname }}
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <strong>Plant Count: </strong>
+    </td>
+    <td>
+      {{ plant.count }}
+    </td>
+  </tr>
+  <br />
+</table>
+
+<mat-dialog-actions>
+  <button mat-button class="button div-center" (click)="close()">Close</button>
+</mat-dialog-actions>

--- a/src/main/webapp/src/app/plant-modal/plant-modal.component.spec.ts
+++ b/src/main/webapp/src/app/plant-modal/plant-modal.component.spec.ts
@@ -1,0 +1,25 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {GrowpodUiModule} from '../common/growpod-ui.module';
+import {PlantModalComponent} from './plant-modal.component';
+
+describe('PlantModalComponent', () => {
+  let component: PlantModalComponent;
+  let fixture: ComponentFixture<PlantModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [GrowpodUiModule],
+      declarations: [PlantModalComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PlantModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/webapp/src/app/plant-modal/plant-modal.component.ts
+++ b/src/main/webapp/src/app/plant-modal/plant-modal.component.ts
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, OnInit, Inject} from '@angular/core';
+import {MatDialogRef, MAT_DIALOG_DATA} from '@angular/material/dialog';
+import {Plant} from '../model/plant.model';
+
+@Component({
+  selector: 'plant-modal',
+  templateUrl: './plant-modal.component.html',
+  styleUrls: [
+    './plant-modal.component.css',
+    '../common/growpod-page-styles.css',
+  ],
+})
+
+/**
+ * Simple modal for displaying plant information.
+ *
+ */
+export class PlantModalComponent implements OnInit {
+  constructor(
+    public dialogRef: MatDialogRef<PlantModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public plant: Plant
+  ) {}
+
+  ngOnInit(): void {}
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION
**Major Change:**
1. Add plant detail modal to the garden admin page. Access by clicking on the (i) icon in the admin page.
2. The plant detail modal is a separate component, so any frontend page can display this modal.

![image](https://user-images.githubusercontent.com/42156440/89035657-f4475e00-d300-11ea-9310-1a22ddfb8345.png)
