### PR TITLE
Display Admin Page

### DIFF
--- a/src/main/webapp/src/app/admin-page/admin-page.component.css
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.css
@@ -1,24 +1,3 @@
 .card-padding {
   padding: 20px;
 }
-
-.button-style {
-  display: block;
-  padding: 0.5em 3em;
-  text-decoration: none;
-  border: none;
-  box-sizing: border-box;
-  box-shadow: inset 0 -0.6em 0 -0.35em #003353;
-  background-color: #005c80;
-  color: white;
-}
-
-.button-style:hover {
-  box-shadow: inset 0 -0.6em 0 -0.35em whitesmoke;
-  background-color: white;
-  color: #005c80;
-}
-
-.growpod-spacer {
-  flex: 1 1 auto;
-}

--- a/src/main/webapp/src/app/admin-page/admin-page.component.css
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.css
@@ -1,0 +1,24 @@
+.card-padding {
+  padding: 20px;
+}
+
+.button-style {
+  display: block;
+  padding: 0.5em 3em;
+  text-decoration: none;
+  border: none;
+  box-sizing: border-box;
+  box-shadow: inset 0 -0.6em 0 -0.35em #003353;
+  background-color: #005c80;
+  color: white;
+}
+
+.button-style:hover {
+  box-shadow: inset 0 -0.6em 0 -0.35em whitesmoke;
+  background-color: white;
+  color: #005c80;
+}
+
+.growpod-spacer {
+  flex: 1 1 auto;
+}

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -1,0 +1,77 @@
+<div *ngIf="isLoaded">
+  <div *ngIf="gardenProfile; else errorBlock">
+    <mat-card class="growpod-main-section growpod-card">
+      <div class="card-padding">
+        <mat-card>
+          <h2>{{ gardenProfile.name }}</h2>
+          <h4>
+            Caroline | {{ gardenProfile.lat + " -- " + gardenProfile.lng }}
+          </h4>
+          <button md-raised-button class="button-style">Go back</button>
+        </mat-card>
+      </div>
+
+      <div class="card-padding">
+        <mat-card>
+          <mat-accordion>
+            <mat-expansion-panel hideToggle>
+              <mat-expansion-panel-header>
+                <mat-panel-title> About the garden </mat-panel-title>
+              </mat-expansion-panel-header>
+              <p>Growing all the green things that look like peas.</p>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel hideToggle>
+              <mat-expansion-panel-header>
+                <mat-panel-title> Plants </mat-panel-title>
+              </mat-expansion-panel-header>
+              <mat-list>
+                <mat-list-item role="list-item">
+                  Plant
+                  <span class="mat-list-item-right-align">
+                    <button mat-button>
+                      <mat-icon color="accent">info</mat-icon>
+                    </button>
+                    <button mat-button>
+                      <mat-icon color="warn">delete</mat-icon>
+                    </button>
+                  </span>
+                </mat-list-item>
+              </mat-list>
+            </mat-expansion-panel>
+
+            <mat-expansion-panel hideToggle>
+              <mat-expansion-panel-header>
+                <mat-panel-title> Members </mat-panel-title>
+              </mat-expansion-panel-header>
+              <mat-list role="list">
+                <mat-list-item role="list-item">
+                  Caroline
+                  <span class="mat-list-item-right-align">
+                    <button mat-button>
+                      <mat-icon color="accent">account_circle</mat-icon>
+                    </button>
+                    <button mat-button>
+                      <mat-icon color="warn">delete</mat-icon>
+                    </button>
+                  </span>
+                </mat-list-item>
+              </mat-list>
+            </mat-expansion-panel>
+          </mat-accordion>
+        </mat-card>
+      </div>
+    </mat-card>
+  </div>
+  <!-- Error case -->
+  <ng-template #errorBlock>
+    <mat-card class="growpod-main-section growpod-card">
+      <mat-card-content>
+        <h4 class="text-center">
+          <mat-icon aria-label="Error" color="warn">error</mat-icon>
+          {{ errorMessage }}
+        </h4>
+      </mat-card-content>
+    </mat-card>
+  </ng-template>
+</div>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -5,7 +5,8 @@
         <mat-card>
           <h2>{{ gardenProfile.name }}</h2>
           <h4>
-            {{ gardenManager }} | {{ gardenProfile.lat + " -- " + gardenProfile.lng }}
+            {{ gardenManager }} |
+            {{ gardenProfile.lat + ' -- ' + gardenProfile.lng }}
           </h4>
         </mat-card>
       </div>
@@ -26,7 +27,10 @@
               </mat-expansion-panel-header>
               <mat-list role="list">
                 <div *ngIf="gardenPlantIdList">
-                  <mat-list-item role="list-item" *ngFor="let plantId of gardenPlantIdList">
+                  <mat-list-item
+                    role="list-item"
+                    *ngFor="let plantId of gardenPlantIdList"
+                  >
                     {{ gardenPlantNameMap && gardenPlantNameMap.get(plantId) }}
                     <span class="mat-list-item-right-align">
                       <button mat-button>
@@ -46,10 +50,16 @@
                 <mat-panel-title> Members </mat-panel-title>
               </mat-expansion-panel-header>
               <mat-list role="list">
-                <mat-list-item role="list-item" *ngFor="let userId of gardenUserIdList">
+                <mat-list-item
+                  role="list-item"
+                  *ngFor="let userId of gardenUserIdList"
+                >
                   {{ gardenUserNameMap && gardenUserNameMap.get(userId) }}
                   <span class="mat-list-item-right-align">
-                    <button mat-button [routerLink]="['/page/user-profile', {id: userId}]">
+                    <button
+                      mat-button
+                      [routerLink]="['/page/user-profile', {id: userId}]"
+                    >
                       <mat-icon color="accent">account_circle</mat-icon>
                     </button>
                     <button mat-button>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -5,9 +5,8 @@
         <mat-card>
           <h2>{{ gardenProfile.name }}</h2>
           <h4>
-            Caroline | {{ gardenProfile.lat + " -- " + gardenProfile.lng }}
+            {{ gardenManager }} | {{ gardenProfile.lat + " -- " + gardenProfile.lng }}
           </h4>
-          <button md-raised-button class="button-style">Go back</button>
         </mat-card>
       </div>
 
@@ -18,25 +17,27 @@
               <mat-expansion-panel-header>
                 <mat-panel-title> About the garden </mat-panel-title>
               </mat-expansion-panel-header>
-              <p>Growing all the green things that look like peas.</p>
+              <p>{{ gardenProfile.description }}</p>
             </mat-expansion-panel>
 
             <mat-expansion-panel hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title> Plants </mat-panel-title>
               </mat-expansion-panel-header>
-              <mat-list>
-                <mat-list-item role="list-item">
-                  Plant
-                  <span class="mat-list-item-right-align">
-                    <button mat-button>
-                      <mat-icon color="accent">info</mat-icon>
-                    </button>
-                    <button mat-button>
-                      <mat-icon color="warn">delete</mat-icon>
-                    </button>
-                  </span>
-                </mat-list-item>
+              <mat-list role="list">
+                <div *ngIf="gardenPlantIdList">
+                  <mat-list-item role="list-item" *ngFor="let plantId of gardenPlantIdList">
+                    {{ gardenPlantNameMap && gardenPlantNameMap.get(plantId) }}
+                    <span class="mat-list-item-right-align">
+                      <button mat-button>
+                        <mat-icon color="accent">info</mat-icon>
+                      </button>
+                      <button mat-button>
+                        <mat-icon color="warn">delete</mat-icon>
+                      </button>
+                    </span>
+                  </mat-list-item>
+                </div>
               </mat-list>
             </mat-expansion-panel>
 
@@ -45,10 +46,10 @@
                 <mat-panel-title> Members </mat-panel-title>
               </mat-expansion-panel-header>
               <mat-list role="list">
-                <mat-list-item role="list-item">
-                  Caroline
+                <mat-list-item role="list-item" *ngFor="let userId of gardenUserIdList">
+                  {{ gardenUserNameMap && gardenUserNameMap.get(userId) }}
                   <span class="mat-list-item-right-align">
-                    <button mat-button>
+                    <button mat-button [routerLink]="['/page/user-profile', {id: userId}]">
                       <mat-icon color="accent">account_circle</mat-icon>
                     </button>
                     <button mat-button>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.spec.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.spec.ts
@@ -1,0 +1,26 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {GrowpodUiModule} from '../common/growpod-ui.module';
+import {AdminPageComponent} from './admin-page.component';
+import {DatepickerComponent} from '../datepicker/datepicker.component';
+
+describe('AdminPageComponent', () => {
+  let component: AdminPageComponent;
+  let fixture: ComponentFixture<AdminPageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [GrowpodUiModule],
+      declarations: [AdminPageComponent, DatepickerComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -54,7 +54,7 @@ export class AdminPageComponent implements OnInit {
   // Plant list
   gardenPlantIdList: Array<string> | null = null;
   gardenPlantNameMap: Map<string, string>;
-  gardenPlantIdListError = ''
+  gardenPlantIdListError = '';
   errorMessage = '';
 
   /**
@@ -97,9 +97,7 @@ export class AdminPageComponent implements OnInit {
    *
    * @return the http response.
    */
-  getGardenUserList(
-    garden: string
-  ): Observable<HttpResponse<Array<String>>> {
+  getGardenUserList(garden: string): Observable<HttpResponse<Array<String>>> {
     return this.httpClient.get<Array<String>>(
       '/garden/' + garden + '/user-list',
       {
@@ -116,9 +114,7 @@ export class AdminPageComponent implements OnInit {
    *
    * @return the http response.
    */
-  getGardenPlantList(
-    garden: string
-  ): Observable<HttpResponse<Array<String>>> {
+  getGardenPlantList(garden: string): Observable<HttpResponse<Array<String>>> {
     return this.httpClient.get<Array<String>>(
       '/garden/' + garden + '/plant-list',
       {
@@ -174,7 +170,7 @@ export class AdminPageComponent implements OnInit {
         // Get rest of information
         this.createGardenUserList(garden);
         this.createGardenPlantList(garden);
-        this.gardenManager = "Loading";
+        this.gardenManager = 'Loading';
         this.getUserInfo(this.gardenProfile.adminId).subscribe({
           next: (response: HttpResponse<User>) => {
             this.gardenManager = response.body.preferredName;
@@ -211,7 +207,8 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Error ' + error.status + ': ' + error.statusText);
         this.gardenProfile = null;
-        this.errorMessage = 'Cannot see garden profile for garden id: ' + garden;
+        this.errorMessage =
+          'Cannot see garden profile for garden id: ' + garden;
         this.isLoaded = true;
       },
     });
@@ -230,15 +227,12 @@ export class AdminPageComponent implements OnInit {
         // Gets user names
         this.gardenUserNameMap = new Map<string, string>();
         this.gardenUserIdList.forEach(id => {
-          this.gardenUserNameMap.set(id, "Loading...");
+          this.gardenUserNameMap.set(id, 'Loading...');
           this.getUserInfo(id).subscribe({
             // Obtain user names
             next: (response: HttpResponse<User>) => {
               // Successful responses are handled here.
-              this.gardenUserNameMap.set(
-                id,
-                response.body.preferredName
-              );
+              this.gardenUserNameMap.set(id, response.body.preferredName);
             },
             error: (error: HttpErrorResponse) => {
               // Handle connection error
@@ -271,7 +265,8 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Error ' + error.status + ': ' + error.statusText);
         this.gardenUserIdList = null;
-        this.gardenUserIdListError = 'Cannot see user list for garden id: ' + garden;
+        this.gardenUserIdListError =
+          'Cannot see user list for garden id: ' + garden;
         this.isLoaded = true;
       },
     });
@@ -290,15 +285,12 @@ export class AdminPageComponent implements OnInit {
         // Get plant names
         this.gardenPlantNameMap = new Map<string, string>();
         this.gardenPlantIdList.forEach(id => {
-          this.gardenPlantNameMap.set(id, "Loading...");
+          this.gardenPlantNameMap.set(id, 'Loading...');
           this.getPlantInfo(id).subscribe({
             // Obtain plant names
             next: (response: HttpResponse<Plant>) => {
               // Successful responses are handled here.
-              this.gardenPlantNameMap.set(
-                id,
-                response.body.nickname
-              );
+              this.gardenPlantNameMap.set(id, response.body.nickname);
             },
             error: (error: HttpErrorResponse) => {
               // Handle connection error
@@ -331,7 +323,8 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Error ' + error.status + ': ' + error.statusText);
         this.gardenPlantIdList = null;
-        this.gardenPlantIdListError = 'Cannot see plant list for garden id: ' + garden;
+        this.gardenPlantIdListError =
+          'Cannot see plant list for garden id: ' + garden;
         this.isLoaded = true;
       },
     });

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -188,27 +188,21 @@ export class AdminPageComponent implements OnInit {
         });
       },
       error: (error: HttpErrorResponse) => {
-        // Handle connection error
+        this.gardenProfile = null;
         if (error.error instanceof ErrorEvent) {
+          // Connection Error
           console.error('Network error: ' + error.error.message);
-          this.gardenProfile = null;
           this.errorMessage = 'Cannot connect to GrowPod Server';
-          this.isLoaded = true;
-          return;
-        }
-        // Non-404 error codes
-        if (error.status !== 404) {
+        } else if (error.status !== 404) {
+          // Non-404 statuses
           console.error('Unexpected error: ' + error.statusText);
-          this.gardenProfile = null;
           this.errorMessage =
             'Unexpected error ' + error.status + ': ' + error.statusText;
-          this.isLoaded = true;
-          return;
+        } else {
+          console.error('Error ' + error.status + ': ' + error.statusText);
+          this.errorMessage =
+            'Cannot see garden profile for garden id: ' + garden;
         }
-        console.error('Error ' + error.status + ': ' + error.statusText);
-        this.gardenProfile = null;
-        this.errorMessage =
-          'Cannot see garden profile for garden id: ' + garden;
         this.isLoaded = true;
       },
     });
@@ -248,26 +242,21 @@ export class AdminPageComponent implements OnInit {
         });
       },
       error: (error: HttpErrorResponse) => {
-        // Handle connection error
+        this.gardenUserIdList = null;
         if (error.error instanceof ErrorEvent) {
+          // Handle connection error
           console.error('Network error: ' + error.error.message);
-          this.gardenUserIdList = null;
           this.gardenUserIdListError = 'Cannot connect to GrowPod Server';
-          return;
-        }
-        // Non-404 error codes
-        if (error.status !== 404) {
+        } else if (error.status !== 404) {
+          // Non-404 errors
           console.error('Unexpected error: ' + error.statusText);
-          this.gardenUserIdList = null;
           this.gardenUserIdListError =
             'Unexpected error ' + error.status + ': ' + error.statusText;
-          return;
+        } else {
+          console.error('Error ' + error.status + ': ' + error.statusText);
+          this.gardenUserIdListError =
+            'Cannot see user list for garden id: ' + garden;
         }
-        console.error('Error ' + error.status + ': ' + error.statusText);
-        this.gardenUserIdList = null;
-        this.gardenUserIdListError =
-          'Cannot see user list for garden id: ' + garden;
-        this.isLoaded = true;
       },
     });
   }

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -157,7 +157,7 @@ export class AdminPageComponent implements OnInit {
   }
 
   /**
-   * Creates garden summary.
+   * Creates garden summary on the page.
    *
    * @param garden The garden to create an admin page of.
    */
@@ -215,7 +215,7 @@ export class AdminPageComponent implements OnInit {
   }
 
   /**
-   * Creates garden user list.
+   * Creates garden user list on the page.
    *
    * @param garden The garden to create a user list of.
    */
@@ -273,7 +273,7 @@ export class AdminPageComponent implements OnInit {
   }
 
   /**
-   * Creates garden plant list.
+   * Creates garden plant list on the page.
    *
    * @param garden The garden to create a plant list of.
    */

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -1,0 +1,219 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {
+  HttpClient,
+  HttpResponse,
+  HttpErrorResponse,
+} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import {Garden} from '../model/garden.model';
+import {Plant} from '../model/plant.model';
+import {User} from '../model/user.model';
+
+@Component({
+  selector: 'admin-page',
+  templateUrl: './admin-page.component.html',
+  styleUrls: [
+    './admin-page.component.css',
+    '../common/growpod-page-styles.css',
+  ],
+})
+
+/**
+ * This is a component designed to allow administrators to manage the gardens they
+ * own.
+ *
+ * This page takes an argument 'garden-id'. This is not optional, and determines
+ * the garden that is being administered. Only the garden owner can make changes to
+ * their garden.
+ */
+export class AdminPageComponent implements OnInit {
+  isLoaded = true;
+  gardenProfile: Garden | null;
+  gardenUserIdList: Array<string> | null = null;
+  gardenUserList: Array<User>;
+  gardenPlantIdList: Array<string> | null = null;
+  gardenPlantList: Array<Plant>;
+  errorMessage = '';
+
+  /**
+   * Initializes the component based on provided arguments
+   *
+   * @param route Contains arguments.
+   */
+  constructor(private route: ActivatedRoute, private httpClient: HttpClient) {}
+
+  ngOnInit(): void {
+    const gardenIdArg = this.route.snapshot.paramMap.get('garden-id');
+    if (!gardenIdArg) {
+      this.gardenProfile = null;
+      this.errorMessage = 'No garden-id argument in the query string.';
+      return;
+    }
+    this.createAdminPage(gardenIdArg);
+  }
+
+  /**
+   * Gets garden information for the specified garden from
+   * the server. Returns an observable HTTP response.
+   *
+   * Performs GET: /garden/{garden}
+   *
+   * @param garden The garden reqested from the server.
+   * @return the http response.
+   */
+  getGardenInfo(garden: string): Observable<HttpResponse<Garden>> {
+    return this.httpClient.get<Garden>('/garden/' + garden, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
+   * Gets all users this garden contains.
+   *
+   * Performs GET: /garden/{garden}/user-list
+   *
+   * @return the http response.
+   */
+  getCurrentGardenUserList(
+    garden: string
+  ): Observable<HttpResponse<Array<String>>> {
+    return this.httpClient.get<Array<String>>(
+      '/garden/' + garden + '/user-list',
+      {
+        observe: 'response',
+        responseType: 'json',
+      }
+    );
+  }
+
+  /**
+   * Gets all plants this garden contains.
+   *
+   * Performs GET: /garden/{garden}/plant-list
+   *
+   * @return the http response.
+   */
+  getCurrentGardenPlantList(
+    garden: string
+  ): Observable<HttpResponse<Array<String>>> {
+    return this.httpClient.get<Array<String>>(
+      '/garden/' + garden + '/plant-list',
+      {
+        observe: 'response',
+        responseType: 'json',
+      }
+    );
+  }
+
+  /**
+   * Gets user information for the specified user from
+   * the server. Returns an observable HTTP response.
+   *
+   * Performs GET: /user/{user}
+   *
+   * @param user The user reqested from the server.
+   * @return the http response.
+   */
+  getUserInfo(user: string): Observable<HttpResponse<User>> {
+    return this.httpClient.get<User>('/user/' + user, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
+   * Gets plant information for the specified plant from
+   * the server. Returns an observable HTTP response.
+   *
+   * Performs GET: /plant/{plant}
+   *
+   * @param plant The plant reqested from the server.
+   * @return the http response.
+   */
+  getPlantInfo(plant: string): Observable<HttpResponse<Plant>> {
+    return this.httpClient.get<Plant>('/plant/' + plant, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
+   * Creates garden summary.
+   *
+   * @param garden The garden to create an admin page of.
+   */
+  createGardenSummary(garden: string): void {
+    this.getGardenInfo(garden).subscribe({
+      next: (response: HttpResponse<Garden>) => {
+        // Successful responses are handled here.
+        this.gardenProfile = response.body;
+        this.isLoaded = true;
+        // Get rest of information
+        this.createGardenUserList(garden);
+        this.createGardenPlantList(garden);
+      },
+      error: (error: HttpErrorResponse) => {
+        // Handle connection error
+        if (error.error instanceof ErrorEvent) {
+          console.error('Network error: ' + error.error.message);
+          this.gardenProfile = null;
+          this.errorMessage = 'Cannot connect to GrowPod Server';
+          this.isLoaded = true;
+          return;
+        }
+        // Non-404 error codes
+        if (error.status !== 404) {
+          console.error('Unexpected error: ' + error.statusText);
+          this.gardenProfile = null;
+          this.errorMessage =
+            'Unexpected error ' + error.status + ': ' + error.statusText;
+          this.isLoaded = true;
+          return;
+        }
+        console.error('Error ' + error.status + ': ' + error.statusText);
+        this.gardenProfile = null;
+        this.errorMessage = 'Cannot see garden profile for user id: ' + garden;
+        this.isLoaded = true;
+      },
+    });
+  }
+
+  /**
+   * Creates garden user list.
+   *
+   * @param garden The garden to create a user list of.
+   */
+  createGardenUserList(garden: string): void {}
+
+  /**
+   * Creates garden plant list.
+   *
+   * @param garden The garden to create a plant list of.
+   */
+  createGardenPlantList(garden: string): void {}
+
+  /**
+   * Creates garden administration page based on the given garden id.
+   *
+   * @param garden The garden to create an admin page of.
+   */
+  createAdminPage(garden: string): void {
+    this.createGardenSummary(garden);
+  }
+}

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -43,7 +43,7 @@ import {User} from '../model/user.model';
  */
 export class AdminPageComponent implements OnInit {
   isLoaded = false;
-  gardenProfile: Garden | null;
+  gardenProfile: Garden | null = null;
   gardenManager: string;
 
   // User list
@@ -67,8 +67,8 @@ export class AdminPageComponent implements OnInit {
   ngOnInit(): void {
     const gardenIdArg = this.route.snapshot.paramMap.get('garden-id');
     if (!gardenIdArg) {
-      this.gardenProfile = null;
       this.errorMessage = 'No garden-id argument in the query string.';
+      this.isLoaded = true;
       return;
     }
     this.createAdminPage(gardenIdArg);

--- a/src/main/webapp/src/app/app-routing.module.ts
+++ b/src/main/webapp/src/app/app-routing.module.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLCn
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/main/webapp/src/app/app-routing.module.ts
+++ b/src/main/webapp/src/app/app-routing.module.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020 Google LLCn
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import {FindGardensComponent} from './find-gardens-page/find-gardens.component';
 import {SchedulePageComponent} from './schedule-page/schedule-page.component';
 import {LoginComponent} from './login-signup-page/login-signup.component';
 import {CreateGardensComponent} from './create-gardens-form/create-gardens.component';
+import {AdminPageComponent} from './admin-page/admin-page.component';
 
 /**
  * The routing table for all frontend pages
@@ -36,6 +37,8 @@ const routes: Routes = [
   {path: 'page/schedule', component: SchedulePageComponent},
   {path: 'page/login', component: LoginComponent},
   {path: 'page/create-garden', component: CreateGardensComponent},
+  {path: 'page/admin-page', component: AdminPageComponent},
+  /** Defaults to /my-gardens */
   {path: '', redirectTo: '/page/my-gardens', pathMatch: 'full'},
 ];
 

--- a/src/main/webapp/src/app/app.component.html
+++ b/src/main/webapp/src/app/app.component.html
@@ -2,7 +2,7 @@
 <div *ngIf="isLoggedIn(); else loginPage">
   <mat-toolbar color="primary">
     <mat-toolbar-row>
-      <a routerLink="/page/index"><span>GrowPod</span></a>
+      <a routerLink="/page/my-gardens"><span>GrowPod</span></a>
       <span class="growpod-spacer"></span>
       <a routerLink="/page/my-gardens" routerLinkActive="active">
         <button mat-button class="growpod-link">

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -18,12 +18,7 @@ import {HttpClientModule} from '@angular/common/http';
 import {RouterModule} from '@angular/router';
 
 import {AppRoutingModule} from './app-routing.module';
-import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
-import {MatExpansionModule} from '@angular/material/expansion';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {MatNativeDateModule} from '@angular/material/core';
-import {MatDatepickerModule} from '@angular/material/datepicker';
-import {MatInputModule} from '@angular/material/input';
 import {
   SocialLoginModule,
   SocialAuthServiceConfig,
@@ -38,12 +33,12 @@ import {UserProfileComponent} from './user-profile/user-profile.component';
 import {FindGardensComponent} from './find-gardens-page/find-gardens.component';
 import {SchedulePageComponent} from './schedule-page/schedule-page.component';
 import {LoginComponent} from './login-signup-page/login-signup.component';
+import {CreateGardensComponent} from './create-gardens-form/create-gardens.component';
+import {DatepickerComponent} from './datepicker/datepicker.component';
+import {AdminPageComponent} from './admin-page/admin-page.component';
 import {CLIENT_ID} from './SensitiveData';
 
 const google_oauth_client_id = CLIENT_ID;
-
-import {CreateGardensComponent} from './create-gardens-form/create-gardens.component';
-import {DatepickerComponent} from './datepicker/datepicker.component';
 
 @NgModule({
   declarations: [
@@ -55,23 +50,19 @@ import {DatepickerComponent} from './datepicker/datepicker.component';
     LoginComponent,
     CreateGardensComponent,
     DatepickerComponent,
+    AdminPageComponent,
   ],
   imports: [
     BrowserModule,
     HttpClientModule,
     AppRoutingModule,
     RouterModule,
-    MatExpansionModule,
     FormsModule,
     ReactiveFormsModule,
-    MatDatepickerModule,
-    MatInputModule,
-    MatNativeDateModule,
     SocialLoginModule,
     GrowpodUiModule,
   ],
   providers: [
-    {provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {appearance: 'fill'}},
     {
       provide: 'SocialAuthServiceConfig',
       useValue: {

--- a/src/main/webapp/src/app/common/growpod-page-styles.css
+++ b/src/main/webapp/src/app/common/growpod-page-styles.css
@@ -1,16 +1,3 @@
-.button {
-  display: flex;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 0.5em 3em;
-  text-decoration: none;
-  border: none;
-  box-sizing: border-box;
-  box-shadow: inset 0 -0.6em 0 -0.35em #003353;
-  background-color: #005c80;
-  color: white;
-}
-
 .growpod-main-section {
   display: block;
   margin-top: 32px;
@@ -99,4 +86,8 @@
   object-fit: cover; /* Equivalent of the background-size: cover; of a background-image */
   object-position: center;
   border-radius: 50%;
+}
+
+.mat-list-item-right-align {
+  margin-left: auto;
 }

--- a/src/main/webapp/src/app/common/material.module.ts
+++ b/src/main/webapp/src/app/common/material.module.ts
@@ -25,6 +25,7 @@ import {MatDatepickerModule} from '@angular/material/datepicker';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
 import {MatSelectModule} from '@angular/material/select';
+import {MatListModule} from '@angular/material/list';
 
 @NgModule({
   exports: [
@@ -39,6 +40,7 @@ import {MatSelectModule} from '@angular/material/select';
     MatDatepickerModule,
     MatFormFieldModule,
     MatSelectModule,
+    MatListModule,
   ],
   providers: [
     {provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {appearance: 'fill'}},

--- a/src/main/webapp/src/app/model/plant.model.ts
+++ b/src/main/webapp/src/app/model/plant.model.ts
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Plant interface that corresponds with design doc specs.
+ *
+ */
+export interface Plant {
+  id: string;
+  nickname: string;
+  count: number;
+  plantTypeId: string;
+}


### PR DESCRIPTION
PR #1 of admin page.

**Major Changes:**
1. Add administer page, accessible at `/page/admin-page;garden-id={garden-id}`. Note the way for passing client-side arguments in Angular, as well as that `garden-id` is required.

**For later:**
1. Add frontend unit testing.

![image](https://user-images.githubusercontent.com/42156440/88857965-d8d33a80-d1bc-11ea-9d47-a7668a3a19c1.png)