### PR TITLE
Admin page: Delete users and plants; Add plants (Resubmitted PR #43)

### DIFF
--- a/src/main/java/com/google/growpod/controllers/GardenDao.java
+++ b/src/main/java/com/google/growpod/controllers/GardenDao.java
@@ -23,6 +23,7 @@ import com.google.cloud.datastore.KeyFactory;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
+import com.google.cloud.datastore.StructuredQuery.CompositeFilter;
 import com.google.cloud.datastore.StructuredQuery.PropertyFilter;
 import com.google.growpod.data.ContainsPlant;
 import com.google.growpod.data.Garden;
@@ -169,8 +170,9 @@ public class GardenDao {
     StructuredQuery<Entity> query =
         Query.newEntityQueryBuilder()
             .setKind("HasMember")
-            .setFilter(PropertyFilter.eq("garden-id", gardenId))
-            .setFilter(PropertyFilter.eq("user-id", userId))
+            .setFilter(
+                CompositeFilter.and(
+                    PropertyFilter.eq("garden-id", gardenId), PropertyFilter.eq("user-id", userId)))
             .build();
     QueryResults<Entity> results = datastore.run(query);
     if (!results.hasNext()) {
@@ -200,8 +202,9 @@ public class GardenDao {
     StructuredQuery<Entity> query =
         Query.newEntityQueryBuilder()
             .setKind("ContainsPlant")
-            .setFilter(PropertyFilter.eq("garden-id", gardenId))
-            .setFilter(PropertyFilter.eq("plant-id", plantId))
+            .setFilter(
+                CompositeFilter.and(
+                    PropertyFilter.eq("garden-id", gardenId), PropertyFilter.eq("plant-id", plantId)))
             .build();
     QueryResults<Entity> results = datastore.run(query);
     if (!results.hasNext()) {

--- a/src/main/java/com/google/growpod/controllers/GardenDao.java
+++ b/src/main/java/com/google/growpod/controllers/GardenDao.java
@@ -170,6 +170,7 @@ public class GardenDao {
         Query.newEntityQueryBuilder()
             .setKind("HasMember")
             .setFilter(PropertyFilter.eq("garden-id", gardenId))
+            .setFilter(PropertyFilter.eq("user-id", userId))
             .build();
     QueryResults<Entity> results = datastore.run(query);
     if (!results.hasNext()) {
@@ -200,6 +201,7 @@ public class GardenDao {
         Query.newEntityQueryBuilder()
             .setKind("ContainsPlant")
             .setFilter(PropertyFilter.eq("garden-id", gardenId))
+            .setFilter(PropertyFilter.eq("plant-id", plantId))
             .build();
     QueryResults<Entity> results = datastore.run(query);
     if (!results.hasNext()) {

--- a/src/main/java/com/google/growpod/controllers/GardenDao.java
+++ b/src/main/java/com/google/growpod/controllers/GardenDao.java
@@ -204,7 +204,8 @@ public class GardenDao {
             .setKind("ContainsPlant")
             .setFilter(
                 CompositeFilter.and(
-                    PropertyFilter.eq("garden-id", gardenId), PropertyFilter.eq("plant-id", plantId)))
+                    PropertyFilter.eq("garden-id", gardenId),
+                    PropertyFilter.eq("plant-id", plantId)))
             .build();
     QueryResults<Entity> results = datastore.run(query);
     if (!results.hasNext()) {

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.css
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.css
@@ -7,5 +7,5 @@
 }
 
 .add-plant-form-table {
-  margin-top: 64px; 
+  margin-top: 64px;
 }

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.css
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.css
@@ -1,0 +1,11 @@
+.form {
+  background-color: #00bb98;
+  max-height: 450px;
+  max-width: 400px;
+  margin: 20px auto;
+  text-align: center;
+}
+
+.add-plant-form-table {
+  margin-top: 64px; 
+}

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
@@ -1,4 +1,3 @@
-
 <h2 mat-dialog-title>
   Add Plant
 </h2>
@@ -6,12 +5,17 @@
 <form [formGroup]="plantGroup">
   <mat-form-field class="div-center">
     <mat-label>Plant Nickname</mat-label>
-    <input formControlName="nickname" matInput placeholder="Enter a name">
-    <mat-error *ngIf="plantGroup.controls.nickname.hasError('required') || plantGroup.controls.nickname.hasError('minLength')">
+    <input formControlName="nickname" matInput placeholder="Enter a name" />
+    <mat-error
+      *ngIf="
+        plantGroup.controls.nickname.hasError('required') ||
+        plantGroup.controls.nickname.hasError('minLength')
+      "
+    >
       Nickname is <strong>required</strong>
     </mat-error>
   </mat-form-field>
-  
+
   <br />
 
   <mat-form-field class="div-center">
@@ -33,7 +37,8 @@
 <table class="add-plant-form-table">
   <tr>
     <td><button mat-button class="button" (click)="close()">Cancel</button></td>
-    <td><button mat-button class="button" (click)="submit()">Add Plant</button></td>
+    <td>
+      <button mat-button class="button" (click)="submit()">Add Plant</button>
+    </td>
   </tr>
 </table>
-

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
@@ -1,0 +1,32 @@
+
+<h2 mat-dialog-title>
+  Add Plant
+</h2>
+
+<form [formGroup]="plantGroup">
+  <mat-form-field class="div-center">
+    <mat-label>Plant Nickname</mat-label>
+    <input formControlName="nickname" matInput placeholder="Enter a name">
+    <mat-error *ngIf="plantGroup.controls.nickname.hasError('required') || plantGroup.controls.nickname.hasError('minLength')">
+      Nickname is <strong>required</strong>
+    </mat-error>
+  </mat-form-field>
+  
+  <br />
+
+  <mat-form-field class="div-center">
+    <mat-label>Number of Plants</mat-label>
+    <input formControlName="count" matInput placeholder="Enter a number">
+     <mat-error *ngIf="plantGroup.controls.count.hasError('required') || plantGroup.controls.nickname.hasError('pattern') || plantGroup.controls.nickname.hasError('min')">
+      Number of plants is <strong>required</strong> and must be a positive number.
+    </mat-error>
+  </mat-form-field>
+</form>
+
+<table class="add-plant-form-table">
+  <tr>
+    <td><button mat-button class="button" (click)="close()">Cancel</button></td>
+    <td><button mat-button class="button" (click)="submit()">Add Plant</button></td>
+  </tr>
+</table>
+

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.html
@@ -16,9 +16,16 @@
 
   <mat-form-field class="div-center">
     <mat-label>Number of Plants</mat-label>
-    <input formControlName="count" matInput placeholder="Enter a number">
-     <mat-error *ngIf="plantGroup.controls.count.hasError('required') || plantGroup.controls.nickname.hasError('pattern') || plantGroup.controls.nickname.hasError('min')">
-      Number of plants is <strong>required</strong> and must be a positive number.
+    <input formControlName="count" matInput placeholder="Enter a number" />
+    <mat-error
+      *ngIf="
+        plantGroup.controls.count.hasError('required') ||
+        plantGroup.controls.count.hasError('pattern') ||
+        plantGroup.controls.count.hasError('min')
+      "
+    >
+      Number of plants is <strong>required</strong> and must be a positive
+      number.
     </mat-error>
   </mat-form-field>
 </form>

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.spec.ts
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.spec.ts
@@ -1,0 +1,25 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {GrowpodUiModule} from '../common/growpod-ui.module';
+import {AddPlantComponent} from './add-plant-form.component';
+
+describe('AddPlantComponent', () => {
+  let component: AddPlantComponent;
+  let fixture: ComponentFixture<AddPlantComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [GrowpodUiModule],
+      declarations: [AddPlantComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddPlantComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.ts
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.ts
@@ -1,0 +1,75 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, OnInit} from '@angular/core';
+import {FormGroup, FormControl, Validators} from '@angular/forms';
+import {MatDialogRef} from '@angular/material/dialog';
+import {Plant} from '../model/plant.model';
+
+@Component({
+  selector: 'add-plant-form',
+  templateUrl: './add-plant-form.component.html',
+  styleUrls: [
+    './add-plant-form.component.css',
+    '../common/growpod-page-styles.css',
+  ],
+})
+
+/**
+ * Simple modal for adding a plant.
+ *
+ */
+export class AddPlantComponent implements OnInit {
+  plant: Plant = {
+    id: "1",
+    nickname: undefined,
+    count: undefined,
+    plantTypeId: "1",
+  };
+  plantGroup: FormGroup;
+
+  constructor(public dialogRef: MatDialogRef<AddPlantComponent, Plant>) {}
+
+  ngOnInit(): void {
+    this.plantGroup = new FormGroup({
+      nickname: new FormControl(this.plant.nickname, [
+        Validators.required,
+        Validators.minLength(1),
+      ]),
+      count: new FormControl(this.plant.count, [
+        Validators.required,
+        Validators.pattern("[0-9]+"),
+        Validators.min(1),
+      ])
+    });
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+
+  /**
+   * Closes the dialog with plant provided
+   * the input is valid.
+   *
+   */
+  submit(): void {
+    if (this.plantGroup.valid) {
+      this.plant = this.plantGroup.value;
+      this.plant.id = "1";
+      this.plant.plantTypeId = "1";
+      this.dialogRef.close(this.plant);
+    }
+  }
+}

--- a/src/main/webapp/src/app/add-plant-form/add-plant-form.component.ts
+++ b/src/main/webapp/src/app/add-plant-form/add-plant-form.component.ts
@@ -32,10 +32,10 @@ import {Plant} from '../model/plant.model';
  */
 export class AddPlantComponent implements OnInit {
   plant: Plant = {
-    id: "1",
+    id: '1',
     nickname: undefined,
     count: undefined,
-    plantTypeId: "1",
+    plantTypeId: '1',
   };
   plantGroup: FormGroup;
 
@@ -49,9 +49,9 @@ export class AddPlantComponent implements OnInit {
       ]),
       count: new FormControl(this.plant.count, [
         Validators.required,
-        Validators.pattern("[0-9]+"),
+        Validators.pattern('[0-9]+'),
         Validators.min(1),
-      ])
+      ]),
     });
   }
 
@@ -67,8 +67,8 @@ export class AddPlantComponent implements OnInit {
   submit(): void {
     if (this.plantGroup.valid) {
       this.plant = this.plantGroup.value;
-      this.plant.id = "1";
-      this.plant.plantTypeId = "1";
+      this.plant.id = '1';
+      this.plant.plantTypeId = '1';
       this.dialogRef.close(this.plant);
     }
   }

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -3,7 +3,12 @@
     <mat-card class="growpod-main-section growpod-card">
       <div class="card-padding">
         <mat-card>
-          <h2>{{ gardenProfile.name }}</h2>
+          <button class="right-align" mat-button disabled>
+              <mat-icon color="warn">delete</mat-icon>
+            </button>
+          <h2>
+            {{ gardenProfile.name }}
+          </h2>
           <h4>
             {{ gardenManager }} |
             {{ gardenProfile.lat + ' -- ' + gardenProfile.lng }}
@@ -32,11 +37,11 @@
                     *ngFor="let plantId of gardenPlantIdList"
                   >
                     {{ gardenPlantNameMap && gardenPlantNameMap.get(plantId) }}
-                    <span class="mat-list-item-right-align">
+                    <span class="right-align">
                       <button mat-button>
                         <mat-icon color="accent">info</mat-icon>
                       </button>
-                      <button mat-button>
+                      <button mat-button (click)="removePlant(plantId)">
                         <mat-icon color="warn">delete</mat-icon>
                       </button>
                     </span>
@@ -55,16 +60,23 @@
                   *ngFor="let userId of gardenUserIdList"
                 >
                   {{ gardenUserNameMap && gardenUserNameMap.get(userId) }}
-                  <span class="mat-list-item-right-align">
+                  <span class="right-align">
                     <button
                       mat-button
                       [routerLink]="['/page/user-profile', {id: userId}]"
                     >
                       <mat-icon color="accent">account_circle</mat-icon>
                     </button>
-                    <button mat-button>
-                      <mat-icon color="warn">delete</mat-icon>
-                    </button>
+                    <div *ngIf="userId !== gardenProfile.adminId; else disableDelete">
+                      <button mat-button (click)="removeUser(userId)">
+                        <mat-icon color="warn">delete</mat-icon>
+                      </button>
+                    </div>
+                    <ng-template #disableDelete>
+                      <button mat-button disabled>
+                        <mat-icon>verified_user</mat-icon>
+                      </button>
+                    </ng-template>
                   </span>
                 </mat-list-item>
               </mat-list>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -3,9 +3,6 @@
     <mat-card class="growpod-main-section growpod-card">
       <div class="card-padding">
         <mat-card>
-          <button class="right-align" mat-button disabled>
-              <mat-icon color="warn">delete</mat-icon>
-            </button>
           <h2>
             {{ gardenProfile.name }}
           </h2>
@@ -28,7 +25,14 @@
 
             <mat-expansion-panel hideToggle>
               <mat-expansion-panel-header>
-                <mat-panel-title> Plants </mat-panel-title>
+                  <mat-panel-title> 
+                    Plants
+                  </mat-panel-title>
+                  <mat-panel-description>
+                    <button class="right-align" mat-button (click)="addPlant()">
+                      <mat-icon color="accent">add_circle_outline</mat-icon>
+                    </button>
+                  </mat-panel-description>
               </mat-expansion-panel-header>
               <mat-list role="list">
                 <div *ngIf="gardenPlantIdList">

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -25,14 +25,14 @@
 
             <mat-expansion-panel hideToggle>
               <mat-expansion-panel-header>
-                  <mat-panel-title> 
-                    Plants
-                  </mat-panel-title>
-                  <mat-panel-description>
-                    <button class="right-align" mat-button (click)="addPlant()">
-                      <mat-icon color="accent">add_circle_outline</mat-icon>
-                    </button>
-                  </mat-panel-description>
+                <mat-panel-title>
+                  Plants
+                </mat-panel-title>
+                <mat-panel-description>
+                  <button class="right-align" mat-button (click)="addPlant()">
+                    <mat-icon color="accent">add_circle_outline</mat-icon>
+                  </button>
+                </mat-panel-description>
               </mat-expansion-panel-header>
               <mat-list role="list">
                 <div *ngIf="gardenPlantIdList">

--- a/src/main/webapp/src/app/admin-page/admin-page.component.html
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.html
@@ -71,11 +71,17 @@
                     >
                       <mat-icon color="accent">account_circle</mat-icon>
                     </button>
-                    <div *ngIf="userId !== gardenProfile.adminId; else disableDelete">
+
+                    <span
+                      *ngIf="
+                        userId !== gardenProfile.adminId;
+                        else disableDelete
+                      "
+                    >
                       <button mat-button (click)="removeUser(userId)">
                         <mat-icon color="warn">delete</mat-icon>
                       </button>
-                    </div>
+                    </span>
                     <ng-template #disableDelete>
                       <button mat-button disabled>
                         <mat-icon>verified_user</mat-icon>

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -170,12 +170,12 @@ export class AdminPageComponent implements OnInit {
    *
    * Performs POST: /garden/{{gardenProfile.id}}/plant-list, with
    * body plant.
+   * TODO validate login
    *
    * @param plant the plant to post.
    * @return the http response.
    */
   postPlantToGarden(plant: Plant): Observable<HttpResponse<string>> {
-    console.log(JSON.stringify(plant));
     return this.httpClient.post<string>(
       '/garden/' + this.gardenProfile.id + '/plant-list',
       plant,
@@ -190,6 +190,7 @@ export class AdminPageComponent implements OnInit {
    * Deletes a plant from a garden.
    *
    * Performs GET: /garden/{{gardenProfile.id}}/plant-list/{id}
+   * TODO validate login
    *
    * @param id the plant id to delete.
    * @return the http response.
@@ -208,6 +209,7 @@ export class AdminPageComponent implements OnInit {
    * Deletes a user from a garden.
    *
    * Performs GET: /garden/{{gardenProfile.id}}/user-list/{id}
+   * TODO validate login
    *
    * @param id the user id to delete.
    * @return the http response.

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -170,7 +170,7 @@ export class AdminPageComponent implements OnInit {
    * @param plant the plant to post.
    * @return the http response.
    */
-  postToGardenPlantList(plant: Plant): Observable<HttpResponse<string>> {
+  postPlantToGarden(plant: Plant): Observable<HttpResponse<string>> {
     console.log(JSON.stringify(plant));
     return this.httpClient.post<string>(
       '/garden/' + this.gardenProfile.id + '/plant-list',
@@ -190,7 +190,7 @@ export class AdminPageComponent implements OnInit {
    * @param id the plant id to delete.
    * @return the http response.
    */
-  deleteFromGardenPlantList(id: string): Observable<HttpResponse<string>> {
+  deletePlant(id: string): Observable<HttpResponse<string>> {
     return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/plant-list/' + id, {
       observe: 'response',
       responseType: 'json',
@@ -205,7 +205,7 @@ export class AdminPageComponent implements OnInit {
    * @param id the user id to delete.
    * @return the http response.
    */
-  deleteFromGardenUserList(id: string): Observable<HttpResponse<string>> {
+  deleteUser(id: string): Observable<HttpResponse<string>> {
     return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/user-list/' + id, {
       observe: 'response',
       responseType: 'json',
@@ -403,7 +403,7 @@ export class AdminPageComponent implements OnInit {
     const inputModal = this.dialog.open(AddPlantComponent);
     inputModal.afterClosed().subscribe((plant: Plant | undefined) => {
       if (plant) {
-        this.postToGardenPlantList(plant).subscribe({
+        this.postPlantToGarden(plant).subscribe({
           next: () => {
             this.createGardenPlantList(this.gardenProfile.id);
           },
@@ -426,7 +426,7 @@ export class AdminPageComponent implements OnInit {
    * @param id The plant id to delete.
    */
   removePlant(id: string): void {
-    this.deleteFromGardenPlantList(id).subscribe({
+    this.deletePlant(id).subscribe({
       next: () => {
         this.createGardenPlantList(this.gardenProfile.id);
       },
@@ -447,7 +447,7 @@ export class AdminPageComponent implements OnInit {
    * @param id The user id to delete.
    */
   removeUser(id: string): void {
-    this.deleteFromGardenUserList(id).subscribe({
+    this.deleteUser(id).subscribe({
       next: () => {
         this.createGardenUserList(this.gardenProfile.id);
       },

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -20,6 +20,8 @@ import {
   HttpErrorResponse,
 } from '@angular/common/http';
 import {Observable} from 'rxjs';
+import {MatDialog} from '@angular/material/dialog';
+import {AddPlantComponent} from '../add-plant-form/add-plant-form.component';
 import {Garden} from '../model/garden.model';
 import {Plant} from '../model/plant.model';
 import {User} from '../model/user.model';
@@ -64,7 +66,7 @@ export class AdminPageComponent implements OnInit {
    *
    * @param route Contains arguments.
    */
-  constructor(private route: ActivatedRoute, private httpClient: HttpClient) {}
+  constructor(private route: ActivatedRoute, private httpClient: HttpClient, private dialog: MatDialog) {}
 
   ngOnInit(): void {
     const gardenIdArg = this.route.snapshot.paramMap.get('garden-id');
@@ -157,6 +159,27 @@ export class AdminPageComponent implements OnInit {
       observe: 'response',
       responseType: 'json',
     });
+  }
+
+  /**
+   * Posts a plant to a garden.
+   *
+   * Performs POST: /garden/{{gardenProfile.id}}/plant-list, with
+   * body plant.
+   *
+   * @param plant the plant to post.
+   * @return the http response.
+   */
+  postToGardenPlantList(plant: Plant): Observable<HttpResponse<string>> {
+    console.log(JSON.stringify(plant));
+    return this.httpClient.post<string>(
+      '/garden/' + this.gardenProfile.id + '/plant-list',
+      plant,
+      {
+        observe: 'response',
+        responseType: 'json',
+      }
+    );
   }
 
   /**
@@ -370,6 +393,31 @@ export class AdminPageComponent implements OnInit {
    */
   createAdminPage(garden: string): void {
     this.createGardenSummary(garden);
+  }
+
+  /**
+   * Shows a modal to add a plant to the garden, then adds it.
+   *
+   */
+  addPlant(): void {
+    const inputModal = this.dialog.open(AddPlantComponent);
+    inputModal.afterClosed().subscribe((plant: Plant | undefined) => {
+      if (plant) {
+        this.postToGardenPlantList(plant).subscribe({
+          next: () => {
+            this.createGardenPlantList(this.gardenProfile.id);
+          },
+          error: (error: HttpErrorResponse) => {
+            // Do nothing visible for errors, yet
+            if (error.error instanceof ErrorEvent) {
+              console.error('Network error: ' + error.error.message);
+              return;
+            }
+            console.error('Unexpected error: ' + error.statusText);
+          },
+        });
+      }
+    });
   }
 
   /**

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -66,7 +66,11 @@ export class AdminPageComponent implements OnInit {
    *
    * @param route Contains arguments.
    */
-  constructor(private route: ActivatedRoute, private httpClient: HttpClient, private dialog: MatDialog) {}
+  constructor(
+    private route: ActivatedRoute,
+    private httpClient: HttpClient,
+    private dialog: MatDialog
+  ) {}
 
   ngOnInit(): void {
     const gardenIdArg = this.route.snapshot.paramMap.get('garden-id');
@@ -186,30 +190,36 @@ export class AdminPageComponent implements OnInit {
    * Deletes a plant from a garden.
    *
    * Performs GET: /garden/{{gardenProfile.id}}/plant-list/{id}
-   * 
+   *
    * @param id the plant id to delete.
    * @return the http response.
    */
   deletePlant(id: string): Observable<HttpResponse<string>> {
-    return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/plant-list/' + id, {
-      observe: 'response',
-      responseType: 'json',
-    });
+    return this.httpClient.delete<string>(
+      '/garden/' + this.gardenProfile.id + '/plant-list/' + id,
+      {
+        observe: 'response',
+        responseType: 'json',
+      }
+    );
   }
 
   /**
    * Deletes a user from a garden.
    *
    * Performs GET: /garden/{{gardenProfile.id}}/user-list/{id}
-   * 
+   *
    * @param id the user id to delete.
    * @return the http response.
    */
   deleteUser(id: string): Observable<HttpResponse<string>> {
-    return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/user-list/' + id, {
-      observe: 'response',
-      responseType: 'json',
-    });
+    return this.httpClient.delete<string>(
+      '/garden/' + this.gardenProfile.id + '/user-list/' + id,
+      {
+        observe: 'response',
+        responseType: 'json',
+      }
+    );
   }
 
   /**
@@ -438,7 +448,7 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Unexpected error: ' + error.statusText);
       },
-    })
+    });
   }
 
   /**
@@ -459,6 +469,6 @@ export class AdminPageComponent implements OnInit {
         }
         console.error('Unexpected error: ' + error.statusText);
       },
-    })
+    });
   }
 }

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -160,6 +160,36 @@ export class AdminPageComponent implements OnInit {
   }
 
   /**
+   * Deletes a plant from a garden.
+   *
+   * Performs GET: /garden/{{gardenProfile.id}}/plant-list/{id}
+   * 
+   * @param id the plant id to delete.
+   * @return the http response.
+   */
+  deleteFromGardenPlantList(id: string): Observable<HttpResponse<string>> {
+    return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/plant-list/' + id, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
+   * Deletes a user from a garden.
+   *
+   * Performs GET: /garden/{{gardenProfile.id}}/user-list/{id}
+   * 
+   * @param id the user id to delete.
+   * @return the http response.
+   */
+  deleteFromGardenUserList(id: string): Observable<HttpResponse<string>> {
+    return this.httpClient.delete<string>('/garden/' + this.gardenProfile.id + '/user-list/' + id, {
+      observe: 'response',
+      responseType: 'json',
+    });
+  }
+
+  /**
    * Creates garden summary.
    *
    * @param garden The garden to create an admin page of.
@@ -340,5 +370,47 @@ export class AdminPageComponent implements OnInit {
    */
   createAdminPage(garden: string): void {
     this.createGardenSummary(garden);
+  }
+
+  /**
+   * Removes a plant from a garden.
+   *
+   * @param id The plant id to delete.
+   */
+  removePlant(id: string): void {
+    this.deleteFromGardenPlantList(id).subscribe({
+      next: () => {
+        this.createGardenPlantList(this.gardenProfile.id);
+      },
+      error: (error: HttpErrorResponse) => {
+        // Do nothing visible for errors, yet
+        if (error.error instanceof ErrorEvent) {
+          console.error('Network error: ' + error.error.message);
+          return;
+        }
+        console.error('Unexpected error: ' + error.statusText);
+      },
+    })
+  }
+
+  /**
+   * Removes a user from a garden.
+   *
+   * @param id The user id to delete.
+   */
+  removeUser(id: string): void {
+    this.deleteFromGardenUserList(id).subscribe({
+      next: () => {
+        this.createGardenUserList(this.gardenProfile.id);
+      },
+      error: (error: HttpErrorResponse) => {
+        // Do nothing visible for errors, yet
+        if (error.error instanceof ErrorEvent) {
+          console.error('Network error: ' + error.error.message);
+          return;
+        }
+        console.error('Unexpected error: ' + error.statusText);
+      },
+    })
   }
 }

--- a/src/main/webapp/src/app/admin-page/admin-page.component.ts
+++ b/src/main/webapp/src/app/admin-page/admin-page.component.ts
@@ -56,7 +56,7 @@ export class AdminPageComponent implements OnInit {
   // Plant list
   gardenPlantIdList: Array<string> | null = null;
   gardenPlantNameMap: Map<string, string>;
-  gardenPlantIdListError = '';
+  gardenPlantIdListError = 'Plant list not loaded';
 
   // General Error Handling
   errorMessage = '';

--- a/src/main/webapp/src/app/app-routing.module.ts
+++ b/src/main/webapp/src/app/app-routing.module.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLCn
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -36,6 +36,7 @@ import {LoginComponent} from './login-signup-page/login-signup.component';
 import {CreateGardensComponent} from './create-gardens-form/create-gardens.component';
 import {DatepickerComponent} from './datepicker/datepicker.component';
 import {AdminPageComponent} from './admin-page/admin-page.component';
+import {AddPlantComponent} from './add-plant-form/add-plant-form.component';
 import {CLIENT_ID} from './SensitiveData';
 
 const google_oauth_client_id = CLIENT_ID;
@@ -51,6 +52,7 @@ const google_oauth_client_id = CLIENT_ID;
     CreateGardensComponent,
     DatepickerComponent,
     AdminPageComponent,
+    AddPlantComponent,
   ],
   imports: [
     BrowserModule,
@@ -75,6 +77,9 @@ const google_oauth_client_id = CLIENT_ID;
         ],
       } as SocialAuthServiceConfig,
     },
+  ],
+  entryComponents: [
+    AddPlantComponent,
   ],
 
   bootstrap: [AppComponent],

--- a/src/main/webapp/src/app/app.module.ts
+++ b/src/main/webapp/src/app/app.module.ts
@@ -78,9 +78,7 @@ const google_oauth_client_id = CLIENT_ID;
       } as SocialAuthServiceConfig,
     },
   ],
-  entryComponents: [
-    AddPlantComponent,
-  ],
+  entryComponents: [AddPlantComponent],
 
   bootstrap: [AppComponent],
 })

--- a/src/main/webapp/src/app/common/growpod-page-styles.css
+++ b/src/main/webapp/src/app/common/growpod-page-styles.css
@@ -88,6 +88,6 @@
   border-radius: 50%;
 }
 
-.mat-list-item-right-align {
+.right-align {
   margin-left: auto;
 }

--- a/src/main/webapp/src/app/common/growpod-page-styles.css
+++ b/src/main/webapp/src/app/common/growpod-page-styles.css
@@ -91,3 +91,7 @@
 .right-align {
   margin-left: auto;
 }
+
+.div-center {
+  margin: 0 auto;
+}

--- a/src/main/webapp/src/app/common/material.module.ts
+++ b/src/main/webapp/src/app/common/material.module.ts
@@ -26,6 +26,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {MAT_FORM_FIELD_DEFAULT_OPTIONS} from '@angular/material/form-field';
 import {MatSelectModule} from '@angular/material/select';
 import {MatListModule} from '@angular/material/list';
+import {MatDialogModule} from '@angular/material/dialog';
 
 @NgModule({
   exports: [
@@ -41,6 +42,7 @@ import {MatListModule} from '@angular/material/list';
     MatFormFieldModule,
     MatSelectModule,
     MatListModule,
+    MatDialogModule,
   ],
   providers: [
     {provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: {appearance: 'fill'}},


### PR DESCRIPTION
**Major Changes:**
1. Allow admins to add plants to their gardens. Input is validated using Angular `FormControl` validation. No authentication is done since login hasn't been merged yet.
2. Allow admins to remove users and plants.

**For later:**
1. Add frontend unit testing.
2. Allow editing of plant nickname
3. Styling tweaks
4. STRETCH: Add geocoding.

![image](https://user-images.githubusercontent.com/42156440/88858045-ff917100-d1bc-11ea-8973-7f9e49c5a854.png)
![image](https://user-images.githubusercontent.com/42156440/88858292-631b9e80-d1bd-11ea-8975-8a7ffd82b1e2.png)
![image](https://user-images.githubusercontent.com/42156440/88858348-7a5a8c00-d1bd-11ea-8282-5d7bd002b713.png)